### PR TITLE
chore: update dependabot commit messages and release configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     assignees:
       - "viamin"
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [0.5.0](https://github.com/viamin/aidp/compare/v0.4.0...v0.5.0) (2025-08-24)
 
-
 ### Features
 
 * add background job option and update analysis steps in CLI ([ae8780c](https://github.com/viamin/aidp/commit/ae8780c6002517bd608eceea76073f2314b8ef93))
@@ -16,13 +15,11 @@
 * implement provider management and enhance CLI analysis functionality ([71d266c](https://github.com/viamin/aidp/commit/71d266c9f5d7b2c7dea7dda51759c6cda693f29b))
 * update release-please configuration for Ruby; add changelog sections and pull request title pattern ([b7d01e0](https://github.com/viamin/aidp/commit/b7d01e0c66fe56b6bc777099ebb06f2b67d9024f))
 
-
 ### Bug Fixes
 
 * correct key name from "version-file" to "version_file" in release configuration ([2202349](https://github.com/viamin/aidp/commit/2202349463854228165ff64c84a4cbbd0740c14f))
 * remove redundant "release-type" key from release configuration ([f74f5c1](https://github.com/viamin/aidp/commit/f74f5c19277b11dfe9745815ffb1fad71516d8b1))
 * rspec setup for testing ([0233047](https://github.com/viamin/aidp/commit/02330472cfe8cef2c024ccee5989d82f825de3ff))
-
 
 ### Improvements
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,14 +11,38 @@
       "package-name": "aidp",
       "version-file": "lib/aidp/version.rb",
       "changelog-sections": [
-        {"type": "feat", "section": "Features"},
-        {"type": "fix", "section": "Bug Fixes"}, 
-        {"type": "refactor", "section": "Improvements"},
-        {"type": "chore", "section": "Maintenance", "hidden": true},
-        {"type": "docs", "section": "Documentation"},
-        {"type": "test", "section": "Testing"},
-        {"type": "ci", "section": "CI/CD"},
-        {"type": "BREAKING CHANGE", "section": "Breaking Changes"}
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "refactor",
+          "section": "Improvements"
+        },
+        {
+          "type": "chore",
+          "section": "Maintenance"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "test",
+          "section": "Testing"
+        },
+        {
+          "type": "ci",
+          "section": "CI/CD"
+        },
+        {
+          "type": "BREAKING CHANGE",
+          "section": "Breaking Changes"
+        }
       ],
       "release-search-depth": 400,
       "commit-search-depth": 500


### PR DESCRIPTION
- Updated release-please configuration to improve changelog section formatting.
- Changed commit message prefix for Dependabot updates from "deps" to "chore".