### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c
         id: release


### PR DESCRIPTION
Potential fix for [https://github.com/viamin/aidp/security/code-scanning/6](https://github.com/viamin/aidp/security/code-scanning/6)

To fix the problem, we should add a `permissions` block to the relevant job in the workflow file `.github/workflows/publish.yml`.
The fix is to explicitly set the minimum required permissions for the `release-please` job. Based on documentation for the `release-please-action`, the minimal viable permissions are typically:
- `contents: write` (to create releases and tag code)
- `pull-requests: write` (to open or update release PRs)

The edit should add a new `permissions:` section at the same level as `runs-on:` within the `release-please` job (on/after line 14). No other code changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
