### PR TITLE
fix: add Pathname requirement to tree_sitter_grammar_loader.rb

### DIFF
--- a/lib/aidp/analysis/tree_sitter_grammar_loader.rb
+++ b/lib/aidp/analysis/tree_sitter_grammar_loader.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "pathname"
 require "tree_sitter"
 require "fileutils"
 


### PR DESCRIPTION
Fixes a crash at load time