### PR TITLE
fix: update aidp configuration structure and provider validation

### DIFF
--- a/aidp.yml
+++ b/aidp.yml
@@ -1,12 +1,12 @@
 ---
-:harness:
-  :max_retries: 2
-  :default_provider: cursor
-  :fallback_providers:
+harness:
+  max_retries: 2
+  default_provider: cursor
+  fallback_providers:
   - macos
-  :no_api_keys_required: true
-:providers:
-  :cursor:
+  no_api_keys_required: true
+providers:
+  cursor:
     type: subscription
     priority: 2
     models:
@@ -15,7 +15,7 @@
       file_upload: true
       code_generation: true
       analysis: true
-  :macos:
+  macos:
     type: passthrough
     priority: 1
     models:

--- a/lib/aidp/cli/first_run_wizard.rb
+++ b/lib/aidp/cli/first_run_wizard.rb
@@ -188,17 +188,17 @@ module Aidp
 
         provider_section = {}
         providers.each do |prov|
-          provider_section[prov.to_sym] = {type: (prov == "cursor") ? "package" : "usage_based", default_flags: []}
+          provider_section[prov] = {"type" => (prov == "cursor") ? "package" : "usage_based", "default_flags" => []}
         end
 
         data = {
-          harness: {
-            max_retries: 2,
-            default_provider: provider_name,
-            fallback_providers: fallback_providers,
-            no_api_keys_required: restrict
+          "harness" => {
+            "max_retries" => 2,
+            "default_provider" => provider_name,
+            "fallback_providers" => fallback_providers,
+            "no_api_keys_required" => restrict
           },
-          providers: provider_section
+          "providers" => provider_section
         }
         File.write(dest, YAML.dump(data))
         dest
@@ -248,18 +248,25 @@ module Aidp
         providers.each do |prov|
           # Try to preserve existing provider config if it exists
           existing_provider = providers_config[prov.to_sym] || providers_config[prov.to_s]
-          provider_section[prov.to_sym] = (existing_provider || {type: (prov == "cursor") ? "package" : "usage_based", default_flags: []})
+          if existing_provider
+            # Convert existing provider config to string keys
+            converted_provider = {}
+            existing_provider.each { |k, v| converted_provider[k.to_s] = v }
+            provider_section[prov] = converted_provider
+          else
+            provider_section[prov] = {"type" => (prov == "cursor") ? "package" : "usage_based", "default_flags" => []}
+          end
         end
 
         # Build the new config
         data = {
-          harness: {
-            max_retries: harness_config[:max_retries] || harness_config["max_retries"] || 2,
-            default_provider: provider_name,
-            fallback_providers: fallback_providers,
-            no_api_keys_required: restrict_input
+          "harness" => {
+            "max_retries" => harness_config[:max_retries] || harness_config["max_retries"] || 2,
+            "default_provider" => provider_name,
+            "fallback_providers" => fallback_providers,
+            "no_api_keys_required" => restrict_input
           },
-          providers: provider_section
+          "providers" => provider_section
         }
 
         File.write(dest, YAML.dump(data))

--- a/lib/aidp/harness/configuration.rb
+++ b/lib/aidp/harness/configuration.rb
@@ -298,7 +298,9 @@ module Aidp
         end
 
         # Validate each provider configuration using config_validator
-        configured_providers.each do |provider|
+        # Only validate providers that are actually referenced in the harness configuration
+        providers_to_validate = [default_provider] + fallback_providers
+        providers_to_validate.uniq.each do |provider|
           require_relative "config_validator"
           validator = ConfigValidator.new(@project_dir)
           validation_result = validator.validate_provider(provider)


### PR DESCRIPTION
- Changed YAML keys in aidp.yml from symbols to strings for consistency.
- Updated provider section handling in first_run_wizard.rb to use string keys.
- Enhanced provider validation logic in configuration.rb to only validate referenced providers.