### PR TITLE
fix: update provider types from package to subscription and api to usage_based

### DIFF
--- a/lib/aidp/cli/first_run_wizard.rb
+++ b/lib/aidp/cli/first_run_wizard.rb
@@ -188,7 +188,7 @@ module Aidp
 
         provider_section = {}
         providers.each do |prov|
-          provider_section[prov] = {"type" => (prov == "cursor") ? "package" : "usage_based", "default_flags" => []}
+          provider_section[prov] = {"type" => (prov == "cursor") ? "subscription" : "usage_based", "default_flags" => []}
         end
 
         data = {
@@ -254,7 +254,7 @@ module Aidp
             existing_provider.each { |k, v| converted_provider[k.to_s] = v }
             provider_section[prov] = converted_provider
           else
-            provider_section[prov] = {"type" => (prov == "cursor") ? "package" : "usage_based", "default_flags" => []}
+            provider_section[prov] = {"type" => (prov == "cursor") ? "subscription" : "usage_based", "default_flags" => []}
           end
         end
 

--- a/lib/aidp/config.rb
+++ b/lib/aidp/config.rb
@@ -71,7 +71,7 @@ module Aidp
       },
       providers: {
         cursor: {
-          type: "package",
+          type: "subscription",
           priority: 1,
           default_flags: [],
           models: ["cursor-default", "cursor-fast", "cursor-precise"],
@@ -266,16 +266,16 @@ module Aidp
         },
         providers: {
           cursor: {
-            type: "package",
+            type: "subscription",
             default_flags: []
           },
           claude: {
-            type: "api",
+            type: "usage_based",
             max_tokens: 100_000,
             default_flags: ["--dangerously-skip-permissions"]
           },
           gemini: {
-            type: "api",
+            type: "usage_based",
             max_tokens: 50_000,
             default_flags: []
           }

--- a/templates/aidp-minimal.yml.example
+++ b/templates/aidp-minimal.yml.example
@@ -15,9 +15,9 @@ harness:
 
 # Provider configurations
 providers:
-  # Cursor provider (package-based)
+  # Cursor provider (subscription-based)
   cursor:
-    type: "package"
+    type: "subscription"
     priority: 1
     models: ["cursor-default"]
     features:
@@ -27,7 +27,7 @@ providers:
 
   # Claude provider (API-based)
   claude:
-    type: "api"
+    type: "usage_based"
     priority: 2
     max_tokens: 100000
     models: ["claude-3-5-sonnet-20241022"]

--- a/templates/aidp.yml.example
+++ b/templates/aidp.yml.example
@@ -127,7 +127,7 @@ harness:
 providers:
   # Cursor provider (package-based)
   cursor:
-    type: "package"           # package, api, or passthrough
+    type: "subscription"      # subscription, usage_based, or passthrough
     priority: 1               # Provider priority (higher = more preferred)
     default_flags: []         # Default command-line flags for this provider
 
@@ -227,7 +227,7 @@ providers:
 
   # Claude provider (API-based)
   claude:
-    type: "api"
+    type: "usage_based"
     priority: 2
     max_tokens: 100000        # Maximum tokens per request
     default_flags: ["--dangerously-skip-permissions"]
@@ -278,7 +278,7 @@ providers:
 
   # Gemini provider (API-based)
   gemini:
-    type: "api"
+    type: "usage_based"
     priority: 3
     max_tokens: 50000
     default_flags: []


### PR DESCRIPTION
- Changed provider type for 'cursor' from 'package' to 'subscription' in configuration files and templates.
- Updated related comments and documentation to reflect the new provider type.
- Ensured consistency across all relevant files for the 'claude' and 'gemini' providers, changing their type from 'api' to 'usage_based'.