### PR TITLE
fix: standardize provider types from package to subscription and api to usage_based

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ The TUI automatically switches providers when:
 # aidp.yml
 providers:
   claude:
-    type: "api"
+    type: "usage_based"
     api_key: "${AIDP_CLAUDE_API_KEY}"
     max_tokens: 100000
   gemini:
-    type: "api"
+    type: "usage_based"
     api_key: "${AIDP_GEMINI_API_KEY}"
     max_tokens: 50000
   cursor:
-    type: "package"
+    type: "subscription"
 ```
 
 ### Environment Variables

--- a/docs/harness-configuration.md
+++ b/docs/harness-configuration.md
@@ -31,8 +31,8 @@ providers:
   gemini:
     type: "api"
     max_tokens: 50000
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
 ```
 
 ## Harness Configuration
@@ -186,13 +186,13 @@ providers:
       cost_per_token: 0.00001
 ```
 
-#### Package Providers (Cursor)
+#### Subscription Providers (Cursor)
 
 ```yaml
 providers:
-  cursor:
-    type: "package"
-    # No API key needed for package providers
+    cursor:
+      type: "subscription"
+     # No API key needed for subscription providers
     default_flags: []
     retry_count: 1
     timeout: 60
@@ -268,8 +268,8 @@ providers:
 
 ```yaml
 providers:
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
     default_flags: []
     retry_count: 1
     timeout: 60
@@ -281,12 +281,12 @@ providers:
     # Rate limit handling
     rate_limit_handling:
       strategy: "provider_first"
-      cooldown_period: 0  # No rate limits for package providers
+      cooldown_period: 0  # No rate limits for subscription providers
       max_retries: 1
 
     # Cost optimization
     cost_optimization:
-      enabled: false  # No cost tracking for package providers
+      enabled: false  # No cost tracking for subscription providers
 ```
 
 ## Advanced Configuration
@@ -459,8 +459,8 @@ providers:
     retry_count: 2
     timeout: 45
 
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
     retry_count: 1
     timeout: 60
 ```
@@ -593,12 +593,12 @@ providers:
       max_daily_cost: 50.0
       max_monthly_cost: 500.0
 
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
     retry_count: 1
     timeout: 60
 
-    # No cost tracking for package providers
+    # No cost tracking for subscription providers
     cost_tracking:
       enabled: false
 ```
@@ -649,8 +649,8 @@ providers:
       target_response_time: 2.0
       max_response_time: 5.0
 
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
     retry_count: 2
     timeout: 60
 
@@ -738,10 +738,10 @@ providers:
 # Error: Invalid provider type
 providers:
   claude:
-    type: "invalid_type"  # Should be "api" or "package"
+     type: "invalid_type"  # Should be "usage_based" or "subscription"
 ```
 
-**Solution**: Use `"api"` for API-based providers or `"package"` for package-based providers.
+**Solution**: Use `"usage_based"` for API-based providers or `"subscription"` for subscription-based providers.
 
 #### Invalid Rotation Strategy
 

--- a/docs/harness-migration.md
+++ b/docs/harness-migration.md
@@ -93,8 +93,8 @@ providers:
     type: "api"
     api_key: "${AIDP_GEMINI_API_KEY}"
     max_tokens: 50000
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
 EOF
 ```
 
@@ -331,8 +331,8 @@ providers:
     type: "api"
     api_key: "${AIDP_GEMINI_API_KEY}"
     max_tokens: 50000
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
 ```
 
 ## Error Handling Migration

--- a/docs/harness-usage.md
+++ b/docs/harness-usage.md
@@ -219,8 +219,8 @@ providers:
   gemini:
     type: "api"
     max_tokens: 50000
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
 ```
 
 ### Advanced Configuration
@@ -260,8 +260,8 @@ providers:
     retry_count: 2
     timeout: 45
 
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
     default_flags: []
     retry_count: 1
     timeout: 60

--- a/lib/aidp/cli/first_run_wizard.rb
+++ b/lib/aidp/cli/first_run_wizard.rb
@@ -133,16 +133,16 @@ module Aidp
         dest = File.join(project_dir, "aidp.yml")
         return dest if File.exist?(dest)
         data = {
-          harness: {
-            max_retries: 2,
-            default_provider: "cursor",
-            fallback_providers: ["cursor"],
-            no_api_keys_required: false
+          "harness" => {
+            "max_retries" => 2,
+            "default_provider" => "cursor",
+            "fallback_providers" => ["cursor"],
+            "no_api_keys_required" => false
           },
-          providers: {
-            cursor: {
-              type: "package",
-              default_flags: []
+          "providers" => {
+            "cursor" => {
+              "type" => "subscription",
+              "default_flags" => []
             }
           }
         }

--- a/lib/aidp/harness/configuration.rb
+++ b/lib/aidp/harness/configuration.rb
@@ -47,7 +47,7 @@ module Aidp
         harness_config[:no_api_keys_required]
       end
 
-      # Get provider type (api, package, etc.)
+      # Get provider type (usage_based, subscription, etc.)
       def provider_type(provider_name)
         provider_config(provider_name)[:type] || "unknown"
       end

--- a/spec/aidp/harness/config_schema_spec.rb
+++ b/spec/aidp/harness/config_schema_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Aidp::Harness::ConfigSchema do
         },
         providers: {
           invalid_provider: {
-            type: "invalid_type", # Should be api, package, or passthrough
+            type: "invalid_type", # Should be usage_based, subscription, or passthrough
             max_tokens: -1, # Should be positive
             default_flags: "not_an_array" # Should be array
           }

--- a/templates/README.md
+++ b/templates/README.md
@@ -102,7 +102,7 @@ The `harness` section controls the overall behavior of the harness system:
 
 The `providers` section defines individual provider settings:
 
-- `type`: Provider type (package, api, passthrough)
+- `type`: Provider type (subscription, usage_based, passthrough)
 - `priority`: Provider priority (higher = more preferred)
 - `models`: Available models for the provider
 - `features`: Provider capabilities
@@ -172,9 +172,9 @@ time_based:
 
 ## Provider Types
 
-### Package Providers
+### Subscription Providers
 
-- **Type**: `package`
+- **Type**: `subscription`
 - **Pricing**: Fixed monthly/yearly subscription
 - **Examples**: Cursor Pro
 - **Configuration**: No API keys needed

--- a/templates/aidp-development.yml.example
+++ b/templates/aidp-development.yml.example
@@ -110,8 +110,8 @@ harness:
 # Provider configurations
 providers:
   # Cursor provider (primary for development)
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
     priority: 1
     default_flags: []
 

--- a/templates/aidp-production.yml.example
+++ b/templates/aidp-production.yml.example
@@ -227,8 +227,8 @@ providers:
       max_redirects: 5
 
   # Cursor provider (fallback)
-  cursor:
-    type: "package"
+    cursor:
+      type: "subscription"
     priority: 2
     default_flags: []
 

--- a/templates/aidp.yml.example
+++ b/templates/aidp.yml.example
@@ -125,7 +125,7 @@ harness:
 
 # Provider configurations
 providers:
-  # Cursor provider (package-based)
+  # Cursor provider (subscription-based)
   cursor:
     type: "subscription"      # subscription, usage_based, or passthrough
     priority: 1               # Provider priority (higher = more preferred)
@@ -188,7 +188,7 @@ providers:
 
     # Cost tracking
     cost:
-      input_cost_per_token: 0.0    # Package-based pricing
+      input_cost_per_token: 0.0    # Subscription-based pricing
       output_cost_per_token: 0.0
       fixed_cost_per_request: 0.0
       currency: "USD"
@@ -426,8 +426,8 @@ providers:
   #     metrics_interval: 60
 
 # Provider types explained:
-# - "package": Uses package-based pricing (e.g., Cursor Pro)
-# - "api": Uses API-based pricing with token limits
+# - "subscription": Uses subscription-based pricing (e.g., Cursor Pro)
+# - "usage_based": Uses API-based pricing with token limits
 # - "passthrough": Uses underlying service (user manages API keys)
 
 # Environment-specific configurations


### PR DESCRIPTION
- Updated all instances of provider type 'package' to 'subscription' for the cursor provider across configuration files, templates, and documentation.
- Ensured consistency in comments and examples to reflect the new provider types.
- Adjusted related documentation to clarify the changes in provider types.