### PR TITLE
refactor: configuration management to use unified .aidp directory structure

### DIFF
--- a/.aidp-config.yml
+++ b/.aidp-config.yml
@@ -1,6 +1,0 @@
----
-database:
-  adapter: sqlite
-  database: aidp.db
-  pool: 5
-  timeout: 5000

--- a/lib/aidp/analyze/progress.rb
+++ b/lib/aidp/analyze/progress.rb
@@ -11,7 +11,7 @@ module Aidp
 
       def initialize(project_dir)
         @project_dir = project_dir
-        @progress_file = File.join(project_dir, ".aidp-analyze-progress.yml")
+        @progress_file = File.join(project_dir, ".aidp", "progress", "analyze.yml")
         load_progress
       end
 
@@ -80,6 +80,7 @@ module Aidp
         # In test mode, skip file operations to avoid hanging
         return if ENV["RACK_ENV"] == "test" || defined?(RSpec)
 
+        FileUtils.mkdir_p(File.dirname(@progress_file))
         File.write(@progress_file, @progress.to_yaml)
       end
     end

--- a/lib/aidp/cli/first_run_wizard.rb
+++ b/lib/aidp/cli/first_run_wizard.rb
@@ -102,7 +102,7 @@ module Aidp
       end
 
       def write_minimal_config(project_dir)
-        dest = File.join(project_dir, "aidp.yml")
+        dest = File.join(project_dir, ".aidp", "aidp.yml")
         return dest if File.exist?(dest)
         data = {
           "harness" => {
@@ -118,6 +118,7 @@ module Aidp
             }
           }
         }
+        FileUtils.mkdir_p(File.dirname(dest))
         File.write(dest, YAML.dump(data))
         dest
       end

--- a/lib/aidp/config.rb
+++ b/lib/aidp/config.rb
@@ -165,14 +165,10 @@ module Aidp
     }.freeze
 
     def self.load(project_dir = Dir.pwd)
-      # Try new aidp.yml format first, then fall back to .aidp.yml
-      config_file = File.join(project_dir, "aidp.yml")
-      legacy_config_file = File.join(project_dir, ".aidp.yml")
+      config_file = File.join(project_dir, ".aidp", "aidp.yml")
 
       if File.exist?(config_file)
         load_yaml_config(config_file)
-      elsif File.exist?(legacy_config_file)
-        load_yaml_config(legacy_config_file)
       else
         {}
       end
@@ -248,14 +244,15 @@ module Aidp
 
     # Check if configuration file exists
     def self.config_exists?(project_dir = Dir.pwd)
-      File.exist?(File.join(project_dir, "aidp.yml")) ||
-        File.exist?(File.join(project_dir, ".aidp.yml"))
+      File.exist?(File.join(project_dir, ".aidp", "aidp.yml"))
     end
 
     # Create example configuration file
     def self.create_example_config(project_dir = Dir.pwd)
-      config_path = File.join(project_dir, "aidp.yml")
+      config_path = File.join(project_dir, ".aidp", "aidp.yml")
       return false if File.exist?(config_path)
+
+      FileUtils.mkdir_p(File.dirname(config_path))
 
       example_config = {
         harness: {

--- a/lib/aidp/execute/progress.rb
+++ b/lib/aidp/execute/progress.rb
@@ -11,7 +11,7 @@ module Aidp
 
       def initialize(project_dir)
         @project_dir = project_dir
-        @progress_file = File.join(project_dir, ".aidp-progress.yml")
+        @progress_file = File.join(project_dir, ".aidp", "progress", "execute.yml")
         load_progress
       end
 
@@ -78,6 +78,7 @@ module Aidp
         # In test mode, skip file operations to avoid hanging
         return if ENV["RACK_ENV"] == "test" || defined?(RSpec)
 
+        FileUtils.mkdir_p(File.dirname(@progress_file))
         File.write(@progress_file, @progress.to_yaml)
       end
     end

--- a/lib/aidp/harness/config_validator.rb
+++ b/lib/aidp/harness/config_validator.rb
@@ -76,8 +76,9 @@ module Aidp
         return false if config_exists?
 
         example_config = ConfigSchema.generate_example
-        config_path = File.join(@project_dir, "aidp.yml")
+        config_path = File.join(@project_dir, ".aidp", "aidp.yml")
 
+        FileUtils.mkdir_p(File.dirname(config_path))
         File.write(config_path, YAML.dump(example_config))
         true
       end
@@ -243,14 +244,10 @@ module Aidp
       private
 
       def find_config_file
-        # Try new aidp.yml format first, then fall back to .aidp.yml
-        config_file = File.join(@project_dir, "aidp.yml")
-        legacy_config_file = File.join(@project_dir, ".aidp.yml")
+        config_file = File.join(@project_dir, ".aidp", "aidp.yml")
 
         if File.exist?(config_file)
           config_file
-        elsif File.exist?(legacy_config_file)
-          legacy_config_file
         end
       end
 

--- a/lib/aidp/harness/configuration.rb
+++ b/lib/aidp/harness/configuration.rb
@@ -211,7 +211,7 @@ module Aidp
 
       # Get configuration path
       def config_path
-        File.join(@project_dir, "aidp.yml")
+        File.join(@project_dir, ".aidp", "aidp.yml")
       end
 
       # Get logging configuration

--- a/spec/aidp/analyze/runner_spec.rb
+++ b/spec/aidp/analyze/runner_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Aidp::Analyze::Runner do
     allow(Dir).to receive(:exist?).and_call_original
 
     # Mock only the specific test project files that don't exist
-    allow(File).to receive(:exist?).with("#{project_dir}/.aidp-progress.yml").and_return(false)
-    allow(File).to receive(:exist?).with("#{project_dir}/.aidp/analyze_progress.yml").and_return(false)
+    allow(File).to receive(:exist?).with("#{project_dir}/.aidp/progress/analyze.yml").and_return(false)
     allow(Dir).to receive(:exist?).with("#{project_dir}/.aidp").and_return(true)
+    allow(Dir).to receive(:exist?).with("#{project_dir}/.aidp/progress").and_return(true)
   end
 
   describe "initialization" do

--- a/spec/aidp/cli/first_run_wizard_spec.rb
+++ b/spec/aidp/cli/first_run_wizard_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Aidp::CLI::FirstRunWizard do
       it "creates minimal config automatically" do
         result = described_class.ensure_config(temp_dir, non_interactive: true, prompt: test_prompt)
         expect(result).to be true
-        config_path = File.join(temp_dir, "aidp.yml")
+        config_path = File.join(temp_dir, ".aidp", "aidp.yml")
         expect(File.exist?(config_path)).to be true
         yaml = YAML.load_file(config_path)
         expect(yaml.dig(:harness, :default_provider) || yaml.dig("harness", "default_provider")).to eq("cursor")
@@ -35,7 +35,7 @@ RSpec.describe Aidp::CLI::FirstRunWizard do
       it "creates minimal config automatically" do
         result = described_class.ensure_config(temp_dir, non_interactive: true, prompt: test_prompt)
         expect(result).to be true
-        yaml = YAML.load_file(File.join(temp_dir, "aidp.yml"))
+        yaml = YAML.load_file(File.join(temp_dir, ".aidp", "aidp.yml"))
         harness = yaml["harness"] || yaml[:harness]
         expect(harness["default_provider"] || harness[:default_provider]).to eq("cursor")
       end

--- a/spec/aidp/cli/providers_cli_availability_spec.rb
+++ b/spec/aidp/cli/providers_cli_availability_spec.rb
@@ -5,7 +5,7 @@ require "open3"
 
 RSpec.describe "Providers CLI availability check" do
   let(:temp_dir) { Dir.mktmpdir("aidp_cli_availability_test") }
-  let(:config_file) { File.join(temp_dir, "aidp.yml") }
+  let(:config_file) { File.join(temp_dir, ".aidp", "aidp.yml") }
 
   before do
     # Create test configuration file
@@ -123,5 +123,6 @@ def create_test_configuration
     }
   }
 
+  FileUtils.mkdir_p(File.dirname(config_file))
   File.write(config_file, YAML.dump(config))
 end

--- a/spec/aidp/cli/providers_health_spec.rb
+++ b/spec/aidp/cli/providers_health_spec.rb
@@ -5,7 +5,7 @@ require "open3"
 
 RSpec.describe "Providers Health CLI" do
   let(:temp_dir) { Dir.mktmpdir("aidp_cli_health_test") }
-  let(:config_file) { File.join(temp_dir, "aidp.yml") }
+  let(:config_file) { File.join(temp_dir, ".aidp", "aidp.yml") }
   let(:ansi_regex) { /\e\[[0-9;]*m/ }
 
   before do
@@ -59,5 +59,6 @@ def create_test_configuration
     }
   }
 
+  FileUtils.mkdir_p(File.dirname(config_file))
   File.write(config_file, YAML.dump(config))
 end

--- a/spec/aidp/config_spec.rb
+++ b/spec/aidp/config_spec.rb
@@ -5,14 +5,18 @@ require "tempfile"
 
 RSpec.describe Aidp::Config do
   let(:temp_dir) { Dir.mktmpdir }
-  let(:config_file) { File.join(temp_dir, "aidp.yml") }
+  let(:config_file) { File.join(temp_dir, ".aidp", "aidp.yml") }
+
+  before do
+    FileUtils.mkdir_p(File.dirname(config_file))
+  end
 
   after do
     FileUtils.rm_rf(temp_dir)
   end
 
   describe ".load" do
-    context "when aidp.yml exists" do
+    context "when .aidp/aidp.yml exists" do
       before do
         File.write(config_file, {
           harness: {
@@ -21,26 +25,9 @@ RSpec.describe Aidp::Config do
         }.to_yaml)
       end
 
-      it "loads the configuration from aidp.yml" do
+      it "loads the configuration from .aidp/aidp.yml" do
         config = described_class.load(temp_dir)
         expect(config[:harness][:default_provider]).to eq("test_provider")
-      end
-    end
-
-    context "when only .aidp.yml exists" do
-      let(:legacy_config_file) { File.join(temp_dir, ".aidp.yml") }
-
-      before do
-        File.write(legacy_config_file, {
-          harness: {
-            default_provider: "legacy_provider"
-          }
-        }.to_yaml)
-      end
-
-      it "loads the configuration from .aidp.yml" do
-        config = described_class.load(temp_dir)
-        expect(config[:harness][:default_provider]).to eq("legacy_provider")
       end
     end
 
@@ -149,14 +136,8 @@ RSpec.describe Aidp::Config do
   end
 
   describe ".config_exists?" do
-    it "returns true when aidp.yml exists" do
+    it "returns true when .aidp/aidp.yml exists" do
       File.write(config_file, "test")
-      expect(described_class.config_exists?(temp_dir)).to be true
-    end
-
-    it "returns true when .aidp.yml exists" do
-      legacy_file = File.join(temp_dir, ".aidp.yml")
-      File.write(legacy_file, "test")
       expect(described_class.config_exists?(temp_dir)).to be true
     end
 

--- a/spec/aidp/execute/runner_spec.rb
+++ b/spec/aidp/execute/runner_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Aidp::Execute::Runner do
     allow(Dir).to receive(:exist?).and_call_original
 
     # Mock only the specific test project files that don't exist
-    allow(File).to receive(:exist?).with("#{project_dir}/.aidp-progress.yml").and_return(false)
-    allow(File).to receive(:exist?).with("#{project_dir}/.aidp/execute_progress.yml").and_return(false)
+    allow(File).to receive(:exist?).with("#{project_dir}/.aidp/progress/execute.yml").and_return(false)
     allow(Dir).to receive(:exist?).with("#{project_dir}/.aidp").and_return(true)
+    allow(Dir).to receive(:exist?).with("#{project_dir}/.aidp/progress").and_return(true)
   end
 
   describe "initialization" do

--- a/spec/aidp/harness/config_schema_spec.rb
+++ b/spec/aidp/harness/config_schema_spec.rb
@@ -329,11 +329,12 @@ end
 
 RSpec.describe Aidp::Harness::ConfigValidator do
   let(:project_dir) { "/tmp/test_project" }
-  let(:config_file) { File.join(project_dir, "aidp.yml") }
+  let(:config_file) { File.join(project_dir, ".aidp", "aidp.yml") }
   let(:validator) { described_class.new(project_dir) }
 
   before do
     FileUtils.mkdir_p(project_dir)
+    FileUtils.mkdir_p(File.dirname(config_file))
   end
 
   after do

--- a/spec/aidp/harness/configuration_spec.rb
+++ b/spec/aidp/harness/configuration_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe Aidp::Harness::Configuration do
   let(:project_dir) { "/tmp/test_project" }
-  let(:config_file) { File.join(project_dir, "aidp.yml") }
+  let(:config_file) { File.join(project_dir, ".aidp", "aidp.yml") }
   let(:configuration) { described_class.new(project_dir) }
 
   before do
@@ -528,7 +528,7 @@ RSpec.describe Aidp::Harness::Configuration do
 
   describe "configuration file management" do
     it "returns configuration path" do
-      expect(configuration.config_path).to eq(File.join(project_dir, "aidp.yml"))
+      expect(configuration.config_path).to eq(File.join(project_dir, ".aidp", "aidp.yml"))
     end
 
     it "checks if configuration exists" do

--- a/spec/aidp/harness/performance_simple_spec.rb
+++ b/spec/aidp/harness/performance_simple_spec.rb
@@ -6,7 +6,7 @@ require_relative "../../support/test_prompt"
 
 RSpec.describe "Harness Performance Testing (Simple)", type: :performance do
   let(:project_dir) { Dir.mktmpdir("aidp_harness_performance_simple_test") }
-  let(:config_file) { File.join(project_dir, "aidp.yml") }
+  let(:config_file) { File.join(project_dir, ".aidp", "aidp.yml") }
   let(:test_prompt) { TestPrompt.new }
 
   before do
@@ -420,6 +420,7 @@ RSpec.describe "Harness Performance Testing (Simple)", type: :performance do
       }
     }
 
+    FileUtils.mkdir_p(File.dirname(config_file))
     File.write(config_file, YAML.dump(config))
   end
 

--- a/spec/aidp/harness/provider_config_spec.rb
+++ b/spec/aidp/harness/provider_config_spec.rb
@@ -6,13 +6,14 @@ require_relative "../../../lib/aidp/harness/provider_factory"
 
 RSpec.describe Aidp::Harness::ProviderConfig do
   let(:project_dir) { "/tmp/test_project" }
-  let(:config_file) { File.join(project_dir, "aidp.yml") }
+  let(:config_file) { File.join(project_dir, ".aidp", "aidp.yml") }
   let(:config_manager) { Aidp::Harness::ConfigManager.new(project_dir) }
   let(:provider_name) { "cursor" }
   let(:provider_config) { described_class.new(provider_name, config_manager) }
 
   before do
     FileUtils.mkdir_p(project_dir)
+    FileUtils.mkdir_p(File.dirname(config_file))
   end
 
   after do
@@ -322,7 +323,7 @@ end
 
 RSpec.describe Aidp::Harness::ProviderFactory do
   let(:project_dir) { "/tmp/test_project" }
-  let(:config_file) { File.join(project_dir, "aidp.yml") }
+  let(:config_file) { File.join(project_dir, ".aidp", "aidp.yml") }
   let(:config_manager) { double("ConfigManager") }
   let(:factory) { described_class.new(config_manager) }
 

--- a/spec/aidp/harness/provider_failure_exhausted_spec.rb
+++ b/spec/aidp/harness/provider_failure_exhausted_spec.rb
@@ -5,7 +5,7 @@ require "open3"
 
 RSpec.describe "Provider failure exhaustion handling" do
   let(:temp_dir) { Dir.mktmpdir("aidp_provider_failure_test") }
-  let(:config_file) { File.join(temp_dir, "aidp.yml") }
+  let(:config_file) { File.join(temp_dir, ".aidp", "aidp.yml") }
   let(:configuration) do
     # Create a test configuration file
     create_test_configuration
@@ -84,6 +84,7 @@ RSpec.describe "Provider failure exhaustion handling" do
       }
     }
 
+    FileUtils.mkdir_p(File.dirname(config_file))
     File.write(config_file, YAML.dump(config))
   end
 end

--- a/spec/aidp/harness/runner_spec.rb
+++ b/spec/aidp/harness/runner_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe Aidp::Harness::Runner do
       }
     }
 
-    config_file = File.join(temp_dir, "aidp.yml")
+    config_file = File.join(temp_dir, ".aidp", "aidp.yml")
+    FileUtils.mkdir_p(File.dirname(config_file))
     File.write(config_file, YAML.dump(config_content))
   end
 

--- a/spec/integration/configuration_isolation_spec.rb
+++ b/spec/integration/configuration_isolation_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Unified Configuration in .aidp/", type: :integration do
       expect(File.exist?(analyze_progress_file)).to be false
 
       # Verify progress was saved correctly
-      loaded_data = YAML.load_file(execute_progress_file)
+      loaded_data = YAML.safe_load_file(execute_progress_file)
       expect(loaded_data["completed_steps"]).to include("00_PRD")
 
       # Verify Progress class can load it
@@ -66,7 +66,7 @@ RSpec.describe "Unified Configuration in .aidp/", type: :integration do
       expect(analyze_progress_file).to include(".aidp/progress/analyze.yml")
 
       # Verify progress was saved correctly
-      loaded_data = YAML.load_file(analyze_progress_file)
+      loaded_data = YAML.safe_load_file(analyze_progress_file)
       expect(loaded_data["completed_steps"]).to include("01_REPOSITORY_ANALYSIS")
 
       # Verify Progress class can load it
@@ -98,8 +98,8 @@ RSpec.describe "Unified Configuration in .aidp/", type: :integration do
       expect(File.exist?(analyze_progress_file)).to be true
 
       # Verify isolation - load both files
-      loaded_execute = YAML.load_file(execute_progress_file)
-      loaded_analyze = YAML.load_file(analyze_progress_file)
+      loaded_execute = YAML.safe_load_file(execute_progress_file)
+      loaded_analyze = YAML.safe_load_file(analyze_progress_file)
 
       expect(loaded_execute["completed_steps"]).to include("00_PRD")
       expect(loaded_execute["completed_steps"]).not_to include("01_REPOSITORY_ANALYSIS")
@@ -189,7 +189,7 @@ RSpec.describe "Unified Configuration in .aidp/", type: :integration do
       File.write(user_config_file, user_config.to_yaml)
 
       # Verify settings
-      config_data = YAML.load_file(user_config_file)
+      config_data = YAML.safe_load_file(user_config_file)
       expect(config_data["global_settings"]["log_level"]).to eq("info")
       expect(config_data["harness"]["default_provider"]).to eq("anthropic")
     end


### PR DESCRIPTION
- Removed legacy .aidp.yml configuration file and updated all references to use .aidp/aidp.yml.
- Adjusted progress file paths for both analyze and execute modes to .aidp/progress/analyze.yml and .aidp/progress/execute.yml respectively.
- Updated tests to reflect new configuration paths and ensure isolation between execute and analyze modes.
- Ensured that configuration loading and validation work correctly with the new structure.

Fixes https://github.com/viamin/aidp/issues/83