### PR TITLE
refactor(cli/docs): make Copilot the default interactive mode and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,8 @@ aidp config --interactive
 aidp init
 # Creates LLM_STYLE_GUIDE.md, PROJECT_ANALYSIS.md, CODE_QUALITY_PLAN.md
 
-# Start an interactive workflow
-aidp execute
-
-# Or run in background
-aidp execute --background
+# Start Copilot interactive mode (default)
+aidp
 ```
 
 ### First-Time Setup
@@ -58,16 +55,12 @@ AIDP implements **work loops** - an iterative execution pattern where AI agents 
 
 See [Work Loops Guide](docs/WORK_LOOPS_GUIDE.md) for details.
 
-### Background Execution
+### Job Management
 
-Run workflows in the background while monitoring progress from separate terminals:
+Monitor and control background jobs:
 
 ```bash
-# Start in background
-aidp execute --background
-✓ Started background job: 20251005_235912_a1b2c3d4
-
-# Monitor progress
+# List and manage jobs
 aidp jobs list                        # List all jobs
 aidp jobs status <job_id>             # Show job status
 aidp jobs logs <job_id> --tail        # View recent logs
@@ -102,17 +95,14 @@ aidp checkpoint history 20
 
 ## Command Reference
 
-### Execution Modes
+### Copilot Mode
 
 ```bash
-# Execute mode - Build new features
-aidp execute                    # Interactive workflow selection
-aidp execute --background       # Run in background
-aidp execute --background --follow  # Start and follow logs
+# Start interactive Copilot mode (default)
+aidp                            # AI-guided workflow selection
 
-# Analyze mode - Analyze codebase
-aidp analyze                    # Interactive analysis
-aidp analyze --background       # Background analysis
+# Copilot can perform both analysis and development based on your needs
+# It will interactively help you choose the right approach
 ```
 
 ### Job Management
@@ -329,40 +319,36 @@ The questions file is only created when the AI needs additional information beyo
 ### Standard Interactive Workflow
 
 ```bash
-# Start execute mode
-aidp execute
+# Start Copilot mode (default)
+aidp
 
-# Select workflow type (e.g., "Full PRD to Implementation")
-# Answer any questions interactively
-# Review generated files (PRD, architecture, etc.)
-# Workflow runs automatically with harness managing retries
+# Copilot will guide you through:
+# - Understanding your project goals
+# - Selecting the right workflow (analysis, development, or both)
+# - Answering questions about your requirements
+# - Reviewing generated files (PRD, architecture, etc.)
+# - Automatic execution with harness managing retries
 ```
 
-### Background Workflow with Monitoring
+### Project Analysis
 
 ```bash
-# Terminal 1: Start background execution
-aidp execute --background
-✓ Started background job: 20251005_235912_a1b2c3d4
+# High-level project analysis and documentation
+aidp init
 
-# Terminal 2: Watch progress in real-time
+# Creates:
+# - LLM_STYLE_GUIDE.md
+# - PROJECT_ANALYSIS.md
+# - CODE_QUALITY_PLAN.md
+```
+
+### Progress Monitoring
+
+```bash
+# Watch progress in real-time
 aidp checkpoint summary --watch
 
-# Terminal 3: Monitor job status
-aidp jobs status 20251005_235912_a1b2c3d4 --follow
-
-# Later: Check final results
-aidp checkpoint summary
-aidp jobs logs 20251005_235912_a1b2c3d4 --tail
-```
-
-### Quick Analysis
-
-```bash
-# Run analysis in background
-aidp analyze --background
-
-# Check progress
+# Check job status
 aidp jobs list
 aidp checkpoint summary
 ```

--- a/docs/CLI_USER_GUIDE.md
+++ b/docs/CLI_USER_GUIDE.md
@@ -5,7 +5,7 @@ Complete guide to using the AI Dev Pipeline command-line interface.
 ## Table of Contents
 
 - [Quick Start](#quick-start)
-- [Execution Modes](#execution-modes)
+- [Copilot Mode](#copilot-mode)
 - [Background Jobs](#background-jobs)
 - [Progress Checkpoints](#progress-checkpoints)
 - [System Management](#system-management)
@@ -26,11 +26,11 @@ aidp --version
 # Run setup wizard
 aidp --setup-config
 
-# Start interactive execute mode
-aidp execute
+# Start Copilot interactive mode (default)
+aidp
 
-# Start interactive analyze mode
-aidp analyze
+# High-level project analysis
+aidp init
 
 # Check system status
 aidp status
@@ -42,7 +42,7 @@ When you run AIDP for the first time in a project, it launches a setup wizard:
 
 ```bash
 $ cd /your/project
-$ aidp execute
+$ aidp
 
 Welcome to AIDP Configuration Setup!
 
@@ -62,42 +62,43 @@ The wizard creates an `aidp.yml` file with your chosen configuration. You can re
 aidp --setup-config
 ```
 
-## Execution Modes
+## Copilot Mode
 
-AIDP has two primary modes: **Execute** (build features) and **Analyze** (analyze code).
+Copilot is the unified interactive mode that can perform both analysis and development tasks.
 
-### Execute Mode
-
-Execute mode guides you through building new features from PRD to implementation.
+### Starting Copilot
 
 ```bash
-# Interactive mode - select workflow and answer questions
-aidp execute
+# Start Copilot (default)
+aidp
 
-# Background mode - run without blocking terminal
-aidp execute --background
-
-# Background with log following
-aidp execute --background --follow
+# Copilot will guide you through:
+# - Understanding your project goals
+# - Selecting the right workflow
+# - Performing analysis or development
 ```
 
-**Available Execute Workflows:**
+**What Copilot Can Do:**
 
-- Full PRD to Implementation
-- PRD Only
-- Architecture Only
-- Implementation Only
-- Custom Step Selection
+- Analyze your codebase (architecture, dependencies, quality)
+- Build new features from PRD to implementation
+- Perform security audits
+- Review test coverage
+- Generate documentation
+- And more - just ask!
 
-### Analyze Mode
+### High-Level Project Analysis
 
-Analyze mode examines your codebase and generates insights.
+For initial project setup and documentation:
 
 ```bash
-# Interactive analysis
-aidp analyze
+# Run comprehensive project analysis
+aidp init
 
-# Background analysis
+# Creates:
+# - LLM_STYLE_GUIDE.md
+# - PROJECT_ANALYSIS.md
+# - CODE_QUALITY_PLAN.md
 aidp analyze --background
 
 # Background with log following

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,8 +1,12 @@
-# Migration Guide: From Legacy Interface to Enhanced TUI
+# Migration Guide
 
-This guide helps you migrate from the legacy AIDP interface to the new Enhanced TUI system.
+This guide covers migration between major AIDP versions.
 
-## Overview
+## Enhanced TUI Migration
+
+This section covers migration from the legacy AIDP interface to the new Enhanced TUI system.
+
+### Overview
 
 The Enhanced TUI is a complete overhaul of the AIDP interface that provides:
 

--- a/docs/WORK_LOOPS_GUIDE.md
+++ b/docs/WORK_LOOPS_GUIDE.md
@@ -25,27 +25,25 @@ walkthrough of the bootstrapping process. Use `aidp config --interactive` (see
 [SETUP_WIZARD](SETUP_WIZARD.md)) to define the test, lint, and guard settings
 that the work loop relies on.
 
-## Guided Workflows (Copilot Mode)
+## Copilot Mode
 
-**NEW:** AIDP now includes a **Guided Workflow** feature that acts as your AI copilot to help you choose the right workflow for your needs.
+**As of version 0.15.0**, AIDP uses a unified **Copilot** mode as the default interactive experience. Copilot acts as your AI pair programmer to help you accomplish any task.
 
-### What is Guided Workflow?
+### What is Copilot Mode?
 
-Instead of manually choosing between Analyze and Execute modes and picking specific workflows, the Guided Workflow uses AI to:
+Copilot is the unified interactive mode that replaced the separate Analyze and Execute modes. It uses AI to:
 
 1. **Understand your goal** through a conversational interface
-2. **Match your intent** to AIDP's capabilities
+2. **Match your intent** to AIDP's capabilities (analysis or development)
 3. **Recommend the best workflow** with clear reasoning
 4. **Handle custom needs** by suggesting step combinations or identifying gaps
 
-### How to Use Guided Workflow
+### How to Use Copilot
 
-When you start AIDP, you'll see three options:
+Simply run `aidp` to start Copilot:
 
-```text
-🤖 Guided Workflow (Copilot) - AI helps you choose the right workflow
-🔬 Analyze Mode - Analyze your codebase for insights and recommendations
-🏗️ Execute Mode - Build new features with guided development workflow
+```bash
+aidp
 ```
 
 Select "Guided Workflow" and simply describe what you want to do:


### PR DESCRIPTION
- Make Copilot the default interactive experience: top-level `aidp` now starts the guided workflow.
- CLI: set mode = :guided, rely on workflow_selector to determine actual mode, default actual_mode to :execute when unspecified.
- Remove interactive mode selection (select_mode_interactive) and stop treating `execute`/`analyze` as primary subcommands.
- Update CLI help/examples to reflect Copilot default, simplified bootstrap examples, and job management wording.
- Docs: update README, docs/CLI_USER_GUIDE.md, docs/WORK_LOOPS_GUIDE.md and docs/MIGRATION_GUIDE.md to replace Execute/Analyze patterns with Copilot Mode guidance and adjust background/job examples.

Fixes https://github.com/viamin/aidp/issues/123