### PR TITLE
fix: pre-select fallback providers in setup wizard using display names

### DIFF
--- a/lib/aidp/setup/wizard.rb
+++ b/lib/aidp/setup/wizard.rb
@@ -148,7 +148,9 @@ module Aidp
         # Prompt for fallback providers (excluding the primary), pre-select existing
         existing_fallbacks = Array(get([:harness, :fallback_providers])).map(&:to_s) - [provider_choice]
         fallback_choices = available_providers.reject { |_, name| name == provider_choice }
-        fallback_selected = prompt.multi_select("Select fallback providers (used if primary fails):", default: existing_fallbacks) do |menu|
+        fallback_default_names = existing_fallbacks.filter_map { |provider_name| fallback_choices.key(provider_name) }
+
+        fallback_selected = prompt.multi_select("Select fallback providers (used if primary fails):", default: fallback_default_names) do |menu|
           fallback_choices.each do |display_name, provider_name|
             menu.choice display_name, provider_name
           end


### PR DESCRIPTION
Map existing fallback provider IDs to their menu display names and pass those as the multi_select default so previously configured fallbacks are correctly pre-selected.