### PR TITLE
ci(publish): make "Find release PR" step more robust

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,9 +28,17 @@ jobs:
         id: find-pr
         run: |
           set -euo pipefail
-          PR_JSON=$(gh pr list --label "autorelease: pending" --json number,headRefName --limit 1)
-          PR_NUMBER=$(jq -r '.[0].number // ""' <<< "$PR_JSON")
-          PR_BRANCH=$(jq -r '.[0].headRefName // ""' <<< "$PR_JSON")
+          REPO="${GITHUB_REPOSITORY}"
+          PR_JSON=$(gh pr list --repo "$REPO" --label "autorelease: pending" --json number,headRefName --limit 1 || echo '[]')
+          # Ensure jq is available (GitHub hosted runners have it by default)
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "jq not found; cannot parse release PR JSON" >&2
+            PR_NUMBER=""
+            PR_BRANCH=""
+          else
+            PR_NUMBER=$(jq -r '.[0].number // ""' <<< "$PR_JSON")
+            PR_BRANCH=$(jq -r '.[0].headRefName // ""' <<< "$PR_JSON")
+          fi
           if [ -n "$PR_NUMBER" ]; then
             echo "Found release PR #$PR_NUMBER on branch $PR_BRANCH"
           else


### PR DESCRIPTION
Use --repo to target the current repository, fall back to an empty JSON if gh fails,
and check for jq availability so the step fails gracefully when jq is missing.