### PR TITLE
chore(ci): use canonical github-actions[bot] no-reply email in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,9 +82,9 @@ jobs:
       - name: Commit updated coverage badge to release PR
         env:
           GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: |
           set -euo pipefail
           git status --short


### PR DESCRIPTION
Replace 41898282+github-actions[bot]@users.noreply.github.com with github-actions[bot]@users.noreply.github.com for GIT_AUTHOR_EMAIL and GIT_COMMITTER_EMAIL when committing the coverage badge.