### PR TITLE
feat(harness): add coverage, version-control and interactive testing support; add /tools REPL and docs

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -84,6 +84,283 @@ work_loop:
     evidence_dir: .aidp/evidence
     logs_dir: .aidp/logs
     screenshots_dir: .aidp/screenshots
+  coverage:
+    enabled: true
+    tool: simplecov
+    run_command: "bundle exec rspec"
+    report_paths:
+      - coverage/index.html
+      - coverage/.resultset.json
+    fail_on_drop: false
+    minimum_coverage: 80.0
+  version_control:
+    tool: git
+    behavior: commit
+    conventional_commits: true
+  interactive_testing:
+    enabled: true
+    app_type: web
+    tools:
+      web:
+        playwright_mcp:
+          enabled: true
+          run: "npx playwright test"
+          specs_dir: ".aidp/tests/web"
+```
+
+### Coverage Tools
+
+AIDP can track code coverage and integrate with your existing coverage tools.
+
+#### Supported Tools
+
+- **simplecov** (Ruby): SimpleCov integration
+- **nyc** (JavaScript): NYC/Istanbul integration
+- **istanbul** (JavaScript): Istanbul integration
+- **coverage.py** (Python): Coverage.py integration
+- **go-cover** (Go): go test -cover integration
+- **jest** (JavaScript): Jest coverage integration
+- **other**: Custom coverage tool
+
+#### Configuration Options
+
+- **`enabled`** (boolean): Enable/disable coverage tracking
+- **`tool`** (string): Coverage tool being used
+- **`run_command`** (string): Command to execute coverage
+- **`report_paths`** (array): Paths to coverage report files
+- **`fail_on_drop`** (boolean): Fail the work loop if coverage decreases
+- **`minimum_coverage`** (number): Minimum coverage percentage (0-100)
+
+#### Examples
+
+**Ruby - SimpleCov**:
+
+```yaml
+coverage:
+  enabled: true
+  tool: simplecov
+  run_command: "bundle exec rspec"
+  report_paths:
+    - coverage/index.html
+    - coverage/.resultset.json
+  minimum_coverage: 80.0
+```
+
+**JavaScript - NYC**:
+
+```yaml
+coverage:
+  enabled: true
+  tool: nyc
+  run_command: "nyc npm test"
+  report_paths:
+    - coverage/lcov-report/index.html
+    - coverage/lcov.info
+```
+
+**Python - Coverage.py**:
+
+```yaml
+coverage:
+  enabled: true
+  tool: coverage.py
+  run_command: "coverage run -m pytest"
+  report_paths:
+    - .coverage
+    - htmlcov/index.html
+```
+
+**Go - go test -cover**:
+
+```yaml
+coverage:
+  enabled: true
+  tool: go-cover
+  run_command: "go test -cover ./..."
+  report_paths:
+    - coverage.out
+```
+
+### Version Control Behavior
+
+Configure how AIDP interacts with your version control system during work loops.
+
+#### Configuration Options
+
+- **`tool`** (string): Version control system (git, svn, or none)
+- **`behavior`** (string): What to do with changes in copilot mode:
+  - `nothing`: Manual git operations only
+  - `stage`: Automatically stage changes (git add)
+  - `commit`: Automatically stage and commit changes
+- **`conventional_commits`** (boolean): Use [Conventional Commits](https://www.conventionalcommits.org/) format
+
+#### Behavior by Mode
+
+| Mode | VCS Behavior |
+|------|--------------|
+| **Copilot** | Uses configured `behavior` setting |
+| **Watch** | Always commits changes (ignores `behavior`) |
+| **Daemon** | Always commits changes (ignores `behavior`) |
+
+#### Examples
+
+**Git with Auto-Commit**:
+
+```yaml
+version_control:
+  tool: git
+  behavior: commit
+  conventional_commits: true
+```
+
+**Git with Manual Operations**:
+
+```yaml
+version_control:
+  tool: git
+  behavior: nothing
+  conventional_commits: false
+```
+
+### Interactive Testing Tools
+
+AIDP can integrate with interactive testing tools for web, CLI, and desktop applications.
+
+#### Application Types
+
+##### Web Applications
+
+**Playwright MCP**:
+
+```yaml
+interactive_testing:
+  enabled: true
+  app_type: web
+  tools:
+    web:
+      playwright_mcp:
+        enabled: true
+        run: "npx playwright test"
+        specs_dir: ".aidp/tests/web"
+```
+
+**Chrome DevTools MCP**:
+
+```yaml
+interactive_testing:
+  enabled: true
+  app_type: web
+  tools:
+    web:
+      chrome_devtools_mcp:
+        enabled: true
+        run: "npm run test:chrome"
+        specs_dir: ".aidp/tests/web"
+```
+
+##### CLI Applications
+
+**Expect Scripts**:
+
+```yaml
+interactive_testing:
+  enabled: true
+  app_type: cli
+  tools:
+    cli:
+      expect:
+        enabled: true
+        run: "expect .aidp/tests/cli/smoke.exp"
+        specs_dir: ".aidp/tests/cli"
+```
+
+##### Desktop Applications
+
+**AppleScript (macOS)**:
+
+```yaml
+interactive_testing:
+  enabled: true
+  app_type: desktop
+  tools:
+    desktop:
+      applescript:
+        enabled: true
+        run: "osascript .aidp/tests/desktop/smoke.scpt"
+        specs_dir: ".aidp/tests/desktop"
+```
+
+**Screen Reader Testing**:
+
+```yaml
+interactive_testing:
+  enabled: true
+  app_type: desktop
+  tools:
+    desktop:
+      screen_reader:
+        enabled: true
+        notes: "VoiceOver scripted checks for accessibility"
+```
+
+## Providers
+
+### Model Families
+
+Group providers by model family for better routing and fallback behavior.
+
+```yaml
+providers:
+  anthropic:
+    type: usage_based
+    model_family: claude
+    max_tokens: 100_000
+```
+
+#### Available Families
+
+- **`auto`** (default): Let the provider decide which model to use
+- **`openai_o`**: OpenAI o-series reasoning models (o1, o1-mini)
+- **`claude`**: Anthropic Claude models (Sonnet, Opus, Haiku)
+- **`mistral`**: Mistral AI models (European/open source)
+- **`local`**: Self-hosted/local LLMs
+
+#### Examples
+
+**Claude Models**:
+
+```yaml
+providers:
+  anthropic:
+    type: usage_based
+    model_family: claude
+    models:
+      - claude-3-5-sonnet-20241022
+      - claude-3-opus-20240229
+```
+
+**OpenAI Reasoning Models**:
+
+```yaml
+providers:
+  openai:
+    type: usage_based
+    model_family: openai_o
+    models:
+      - o1-preview
+      - o1-mini
+```
+
+**Local Models**:
+
+```yaml
+providers:
+  ollama:
+    type: passthrough
+    model_family: local
+    models:
+      - llama2
+      - codellama
 ```
 
 ## Non-Functional Requirements (NFRs)

--- a/docs/INTERACTIVE_REPL.md
+++ b/docs/INTERACTIVE_REPL.md
@@ -397,6 +397,110 @@ REPL Macro Status:
 
 ---
 
+#### `/tools`
+
+View and run configured development tools including coverage analysis and interactive testing.
+
+**Usage:**
+
+```text
+/tools <subcommand> [args]
+```
+
+**Subcommands:**
+
+##### `/tools show`
+
+Display all configured tools and their current status.
+
+**Example:**
+
+```text
+aidp[5]> /tools show
+📊 Configured Tools
+==================================================
+
+🔍 Coverage:
+  Tool: simplecov
+  Command: bundle exec rspec
+  Report paths: coverage/index.html
+  Minimum coverage: 80.0%
+
+🗂️  Version Control:
+  Tool: git
+  Behavior: commit
+  Conventional commits: yes
+
+🎯 Interactive Testing:
+  App type: web
+  Web:
+    • playwright_mcp: enabled
+      Run: npx playwright test
+      Specs: .aidp/tests/web
+
+🤖 Model Families:
+  anthropic: claude
+  cursor: auto
+```
+
+##### `/tools coverage`
+
+Run coverage analysis using the configured coverage tool.
+
+**Example:**
+
+```text
+aidp[10]> /tools coverage
+Running coverage with: bundle exec rspec
+(Coverage execution to be implemented in work loop)
+```
+
+**Returns**: `action: :run_coverage` with coverage configuration
+
+**Error Conditions:**
+
+- Coverage not enabled: "Coverage is not enabled. Run 'aidp config --interactive' to configure coverage."
+- Run command missing: "Coverage run command not configured. Run 'aidp config --interactive' to set it up."
+
+##### `/tools test <type>`
+
+Run interactive tests for the specified application type.
+
+**Arguments:**
+
+- `<type>`: Application type (`web`, `cli`, or `desktop`)
+
+**Examples:**
+
+```text
+aidp[12]> /tools test web
+Running web tests:
+  • playwright_mcp: npx playwright test
+(Test execution to be implemented in work loop)
+
+aidp[15]> /tools test cli
+Running cli tests:
+  • expect: expect .aidp/tests/cli/smoke.exp
+(Test execution to be implemented in work loop)
+```
+
+**Returns**: `action: :run_interactive_tests` with test type and enabled tools
+
+**Error Conditions:**
+
+- Interactive testing not enabled: "Interactive testing is not enabled. Run 'aidp config --interactive' to configure it."
+- Missing type argument: "Usage: /tools test `<type>`\n\nTypes: web, cli, desktop"
+- Invalid type: "Invalid test type: mobile. Must be one of: web, cli, desktop"
+- No tools configured: "No web testing tools configured. Run 'aidp config --interactive' to set them up."
+
+**Configuration:**
+
+Tools are configured in `.aidp/aidp.yml`. Run `aidp config --interactive` to configure tools using the wizard.
+
+See [CONFIGURATION.md](CONFIGURATION.md) for detailed configuration options.
+
+---
+
 ### Standard REPL Macros
 
 All standard REPL macros from [REPL_REFERENCE.md](REPL_REFERENCE.md) are also available:

--- a/lib/aidp/config.rb
+++ b/lib/aidp/config.rb
@@ -74,6 +74,7 @@ module Aidp
         cursor: {
           type: "subscription",
           priority: 1,
+          model_family: "auto",
           default_flags: [],
           models: ["cursor-default", "cursor-fast", "cursor-precise"],
           model_weights: {
@@ -108,6 +109,7 @@ module Aidp
         anthropic: {
           type: "usage_based",
           priority: 2,
+          model_family: "claude",
           max_tokens: 100_000,
           default_flags: ["--dangerously-skip-permissions"],
           models: ["claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022", "claude-3-opus-20240229"],
@@ -153,6 +155,7 @@ module Aidp
         macos: {
           type: "passthrough",
           priority: 4,
+          model_family: "auto",
           underlying_service: "cursor",
           models: ["cursor-chat"],
           features: {

--- a/lib/aidp/harness/config_schema.rb
+++ b/lib/aidp/harness/config_schema.rb
@@ -375,7 +375,11 @@ module Aidp
                 max_iterations: 50,
                 test_commands: [],
                 lint_commands: [],
-                units: {}
+                units: {},
+                guards: {enabled: false},
+                version_control: {tool: "git", behavior: "nothing", conventional_commits: false},
+                coverage: {enabled: false},
+                interactive_testing: {enabled: false, app_type: "web"}
               },
               properties: {
                 enabled: {
@@ -543,6 +547,225 @@ module Aidp
                       default: false
                     }
                   }
+                },
+                version_control: {
+                  type: :hash,
+                  required: false,
+                  default: {
+                    tool: "git",
+                    behavior: "nothing",
+                    conventional_commits: false
+                  },
+                  properties: {
+                    tool: {
+                      type: :string,
+                      required: false,
+                      default: "git",
+                      enum: ["git", "svn", "none"]
+                    },
+                    behavior: {
+                      type: :string,
+                      required: false,
+                      default: "nothing",
+                      enum: ["stage", "commit", "nothing"]
+                    },
+                    conventional_commits: {
+                      type: :boolean,
+                      required: false,
+                      default: false
+                    }
+                  }
+                },
+                coverage: {
+                  type: :hash,
+                  required: false,
+                  default: {
+                    enabled: false
+                  },
+                  properties: {
+                    enabled: {
+                      type: :boolean,
+                      required: false,
+                      default: false
+                    },
+                    tool: {
+                      type: :string,
+                      required: false,
+                      enum: ["simplecov", "nyc", "istanbul", "coverage.py", "go-cover", "jest", "other"]
+                    },
+                    run_command: {
+                      type: :string,
+                      required: false
+                    },
+                    report_paths: {
+                      type: :array,
+                      required: false,
+                      default: [],
+                      items: {
+                        type: :string
+                      }
+                    },
+                    fail_on_drop: {
+                      type: :boolean,
+                      required: false,
+                      default: false
+                    },
+                    minimum_coverage: {
+                      type: :number,
+                      required: false,
+                      min: 0.0,
+                      max: 100.0
+                    }
+                  }
+                },
+                interactive_testing: {
+                  type: :hash,
+                  required: false,
+                  default: {
+                    enabled: false,
+                    app_type: "web"
+                  },
+                  properties: {
+                    enabled: {
+                      type: :boolean,
+                      required: false,
+                      default: false
+                    },
+                    app_type: {
+                      type: :string,
+                      required: false,
+                      default: "web",
+                      enum: ["web", "cli", "desktop"]
+                    },
+                    tools: {
+                      type: :hash,
+                      required: false,
+                      default: {},
+                      properties: {
+                        web: {
+                          type: :hash,
+                          required: false,
+                          default: {},
+                          properties: {
+                            playwright_mcp: {
+                              type: :hash,
+                              required: false,
+                              default: {enabled: false},
+                              properties: {
+                                enabled: {
+                                  type: :boolean,
+                                  required: false,
+                                  default: false
+                                },
+                                run: {
+                                  type: :string,
+                                  required: false
+                                },
+                                specs_dir: {
+                                  type: :string,
+                                  required: false,
+                                  default: ".aidp/tests/web"
+                                }
+                              }
+                            },
+                            chrome_devtools_mcp: {
+                              type: :hash,
+                              required: false,
+                              default: {enabled: false},
+                              properties: {
+                                enabled: {
+                                  type: :boolean,
+                                  required: false,
+                                  default: false
+                                },
+                                run: {
+                                  type: :string,
+                                  required: false
+                                },
+                                specs_dir: {
+                                  type: :string,
+                                  required: false,
+                                  default: ".aidp/tests/web"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        cli: {
+                          type: :hash,
+                          required: false,
+                          default: {},
+                          properties: {
+                            expect: {
+                              type: :hash,
+                              required: false,
+                              default: {enabled: false},
+                              properties: {
+                                enabled: {
+                                  type: :boolean,
+                                  required: false,
+                                  default: false
+                                },
+                                run: {
+                                  type: :string,
+                                  required: false
+                                },
+                                specs_dir: {
+                                  type: :string,
+                                  required: false,
+                                  default: ".aidp/tests/cli"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        desktop: {
+                          type: :hash,
+                          required: false,
+                          default: {},
+                          properties: {
+                            applescript: {
+                              type: :hash,
+                              required: false,
+                              default: {enabled: false},
+                              properties: {
+                                enabled: {
+                                  type: :boolean,
+                                  required: false,
+                                  default: false
+                                },
+                                run: {
+                                  type: :string,
+                                  required: false
+                                },
+                                specs_dir: {
+                                  type: :string,
+                                  required: false,
+                                  default: ".aidp/tests/desktop"
+                                }
+                              }
+                            },
+                            screen_reader: {
+                              type: :hash,
+                              required: false,
+                              default: {enabled: false},
+                              properties: {
+                                enabled: {
+                                  type: :boolean,
+                                  required: false,
+                                  default: false
+                                },
+                                notes: {
+                                  type: :string,
+                                  required: false
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -567,6 +790,12 @@ module Aidp
                   default: 1,
                   min: 1,
                   max: 10
+                },
+                model_family: {
+                  type: :string,
+                  required: false,
+                  default: "auto",
+                  enum: ["auto", "openai_o", "claude", "mistral", "local"]
                 },
                 max_tokens: {
                   type: :integer,

--- a/lib/aidp/harness/configuration.rb
+++ b/lib/aidp/harness/configuration.rb
@@ -209,6 +209,86 @@ module Aidp
         guards_config[:bypass] == true
       end
 
+      # Get version control configuration
+      def version_control_config
+        work_loop_config[:version_control] || default_version_control_config
+      end
+
+      # Get VCS tool
+      def vcs_tool
+        version_control_config[:tool]
+      end
+
+      # Get VCS behavior (stage/commit/nothing)
+      def vcs_behavior
+        version_control_config[:behavior]
+      end
+
+      # Check if conventional commits are enabled
+      def conventional_commits?
+        version_control_config[:conventional_commits] == true
+      end
+
+      # Get coverage configuration
+      def coverage_config
+        work_loop_config[:coverage] || default_coverage_config
+      end
+
+      # Check if coverage is enabled
+      def coverage_enabled?
+        coverage_config[:enabled] == true
+      end
+
+      # Get coverage tool
+      def coverage_tool
+        coverage_config[:tool]
+      end
+
+      # Get coverage run command
+      def coverage_run_command
+        coverage_config[:run_command]
+      end
+
+      # Get coverage report paths
+      def coverage_report_paths
+        coverage_config[:report_paths] || []
+      end
+
+      # Check if should fail on coverage drop
+      def coverage_fail_on_drop?
+        coverage_config[:fail_on_drop] == true
+      end
+
+      # Get minimum coverage threshold
+      def coverage_minimum
+        coverage_config[:minimum_coverage]
+      end
+
+      # Get interactive testing configuration
+      def interactive_testing_config
+        work_loop_config[:interactive_testing] || default_interactive_testing_config
+      end
+
+      # Check if interactive testing is enabled
+      def interactive_testing_enabled?
+        interactive_testing_config[:enabled] == true
+      end
+
+      # Get interactive testing app type
+      def interactive_testing_app_type
+        interactive_testing_config[:app_type]
+      end
+
+      # Get interactive testing tools configuration
+      def interactive_testing_tools
+        interactive_testing_config[:tools] || {}
+      end
+
+      # Get model family for a provider
+      def model_family(provider_name)
+        provider_config(provider_name)[:model_family] || "auto"
+      end
+
       # Get provider priority
       def provider_priority(provider_name)
         provider_config(provider_name)[:priority] || 0
@@ -554,6 +634,33 @@ module Aidp
           confirm_files: [],
           max_lines_per_commit: nil,
           bypass: false
+        }
+      end
+
+      def default_version_control_config
+        {
+          tool: "git",
+          behavior: "nothing",
+          conventional_commits: false
+        }
+      end
+
+      def default_coverage_config
+        {
+          enabled: false,
+          tool: nil,
+          run_command: nil,
+          report_paths: [],
+          fail_on_drop: false,
+          minimum_coverage: nil
+        }
+      end
+
+      def default_interactive_testing_config
+        {
+          enabled: false,
+          app_type: "web",
+          tools: {}
         }
       end
 


### PR DESCRIPTION
- Add new work_loop configuration sections: coverage, version_control and interactive_testing
- Extend config schema (ConfigSchema) with defaults and validation for:
  - coverage (tool, run_command, report_paths, fail_on_drop, minimum_coverage)
  - version_control (tool, behavior, conventional_commits)
  - interactive_testing (app_type, tools for web/cli/desktop)
  - provider model_family enum and default
- Implement Harness::Configuration helpers for new sections (coverage_*, vcs_*, interactive_testing_*, model_family)
- Extend setup wizard to configure coverage, interactive testing, VCS behavior and provider model_family
  - Auto-detection helpers for coverage commands/report paths and VCS detection
- Add REPL "/tools" macro to ReplMacros with subcommands:
  - /tools show — display configured tools and status
  - /tools coverage — trigger coverage run action
  - /tools test <type> — trigger interactive test action
- Wire tests:
  - spec coverage for new ConfigSchema validations (coverage, VCS, interactive testing, model_family)
  - spec for REPL /tools command behaviors (show, coverage, test, errors)
- Update documentation:
  - docs/CONFIGURATION.md — examples and descriptions for coverage, version control, interactive testing, model families
  - docs/INTERACTIVE_REPL.md — /tools macro usage and examples
- Minor defaults added to lib/aidp/config.rb for provider entries (model_family)

Fixes #150