### PR TITLE
feat(version-control): configurable commit styles, AI co-authoring, and PR automation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,11 +35,16 @@ RUN apt-get update && apt-get install -y \
     # Clean up
     && rm -rf /var/lib/apt/lists/*
 
-# Install git-delta for better diffs
+# Install git-delta for better diffs (handle multi-arch)
 ARG DELTA_VERSION=0.18.2
-RUN wget https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_amd64.deb \
-    && dpkg -i git-delta_${DELTA_VERSION}_amd64.deb \
-    && rm git-delta_${DELTA_VERSION}_amd64.deb
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+      amd64|arm64) DELTA_ARCH="$ARCH" ;; \
+      *) echo "Unsupported architecture for git-delta: $ARCH" >&2 && exit 1 ;; \
+    esac \
+    && wget "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/git-delta_${DELTA_VERSION}_${DELTA_ARCH}.deb" \
+    && dpkg -i "git-delta_${DELTA_VERSION}_${DELTA_ARCH}.deb" \
+    && rm "git-delta_${DELTA_VERSION}_${DELTA_ARCH}.deb"
 
 # Install mise (asdf successor) for version management
 RUN curl https://mise.run | sh
@@ -100,12 +105,5 @@ WORKDIR /workspace
 # Install Ruby gems globally for development
 ENV GEM_HOME="/home/$USERNAME/.gem"
 ENV PATH="$GEM_HOME/bin:$PATH"
-
-# Pre-install common development gems
-RUN gem install bundler rake rspec rubocop standard
-
-# Install Claude Code CLI (if not using macOS provider)
-# Note: This can be customized per-project in devcontainer.json
-RUN npm_config_user=root sudo npm install -g @anthropic-ai/claude-code || true
 
 CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -92,10 +92,17 @@
   "workspaceFolder": "/workspace",
 
   // Post-create command - install dependencies
-  "postCreateCommand": "bundle install",
+  "postCreateCommand": {
+    "gem-dependencies": "gem install bundler git-curate || true",
+    "install-claude": "npm install -g @anthropic-ai/claude-code || true",
+    "install-markdownlint": "npm install -g markdownlint-cli || true"
+  },
 
   // Post-start command - initialize firewall
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  "postStartCommand": {
+    "init-firewall": "sudo /usr/local/bin/init-firewall.sh",
+    "ensure-bundle": "bundle check || bundle install --jobs 4 --retry 3"
+  },
   "waitFor": "postStartCommand",
 
   // Features to install
@@ -103,7 +110,10 @@
     // GitHub CLI
     "ghcr.io/devcontainers/features/github-cli:1": {},
     // Docker-in-Docker (for testing)
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      // Debian trixie dropped moby packages; use Docker CE instead
+      "moby": false
+    }
   },
 
   // Port forwarding - none needed by default

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -193,6 +193,16 @@ Configure how AIDP interacts with your version control system during work loops.
   - `stage`: Automatically stage changes (git add)
   - `commit`: Automatically stage and commit changes
 - **`conventional_commits`** (boolean): Use [Conventional Commits](https://www.conventionalcommits.org/) format
+- **`commit_style`** (string): Conventional commit style (only when `conventional_commits: true`):
+  - `default`: Basic conventional format (e.g., `feat: add user authentication`)
+  - `angular`: Include scope in parentheses (e.g., `feat(auth): add login`)
+  - `emoji`: Add emoji prefix (e.g., `✨ feat: add user authentication`)
+- **`co_author_ai`** (boolean): Include "Co-authored-by" attribution with AI provider name (default: true)
+- **`auto_create_pr`** (boolean): Automatically create pull requests after successful builds in watch/daemon mode (default: false)
+- **`pr_strategy`** (string): How to create pull requests (only when `auto_create_pr: true`):
+  - `draft`: Create as draft PR (safe, allows review before merge)
+  - `ready`: Create as ready PR (immediately reviewable)
+  - `auto_merge`: Create and auto-merge (fully autonomous, requires approval rules)
 
 #### Behavior by Mode
 
@@ -204,15 +214,6 @@ Configure how AIDP interacts with your version control system during work loops.
 
 #### Examples
 
-**Git with Auto-Commit**:
-
-```yaml
-version_control:
-  tool: git
-  behavior: commit
-  conventional_commits: true
-```
-
 **Git with Manual Operations**:
 
 ```yaml
@@ -221,6 +222,92 @@ version_control:
   behavior: nothing
   conventional_commits: false
 ```
+
+**Git with Basic Auto-Commit**:
+
+```yaml
+version_control:
+  tool: git
+  behavior: commit
+  conventional_commits: true
+  commit_style: default
+  co_author_ai: true
+```
+
+**Git with Angular-Style Commits**:
+
+```yaml
+version_control:
+  tool: git
+  behavior: commit
+  conventional_commits: true
+  commit_style: angular
+  co_author_ai: true
+```
+
+**Git with Emoji Commits**:
+
+```yaml
+version_control:
+  tool: git
+  behavior: commit
+  conventional_commits: true
+  commit_style: emoji
+  co_author_ai: true
+```
+
+**Fully Autonomous (Watch/Daemon Mode)**:
+
+```yaml
+version_control:
+  tool: git
+  behavior: commit
+  conventional_commits: true
+  commit_style: emoji
+  co_author_ai: true
+  auto_create_pr: true
+  pr_strategy: draft  # or "ready" or "auto_merge"
+```
+
+#### Commit Message Examples
+
+Based on issue #123 "Add feature":
+
+- **Simple (no conventional commits)**:
+
+  ```text
+  implement #123 Add feature
+  ```
+
+- **Default conventional**:
+
+  ```text
+  feat: implement #123 Add feature
+
+  Co-authored-by: Claude <ai@aidp.dev>
+  ```
+
+- **Angular style**:
+
+  ```text
+  feat(implementation): implement #123 Add feature
+
+  Co-authored-by: Claude <ai@aidp.dev>
+  ```
+
+- **Emoji style**:
+
+  ```text
+  ✨ feat: implement #123 Add feature
+
+  Co-authored-by: Claude <ai@aidp.dev>
+  ```
+
+- **Without co-author attribution**:
+
+  ```text
+  feat: implement #123 Add feature
+  ```
 
 ### Interactive Testing Tools
 

--- a/docs/MEMORY_INTEGRATION.md
+++ b/docs/MEMORY_INTEGRATION.md
@@ -40,7 +40,7 @@ This document presents the investigation results for integrating long-term memor
 
 **Current AIDP prompt composition** (without MCP servers):
 
-```
+```text
 - Task description: 200 tokens
 - Style guide fragments (optimized): 3,000 tokens
 - Template fragments (optimized): 2,000 tokens
@@ -217,7 +217,7 @@ Users can install memory-bank-mcp or Beads MCP servers and AIDP will automatical
 
 1. **Design Rationale Recall**
 
-   ```
+   ```text
    Agent: "Why did we choose this authentication pattern?"
    Memory Bank: [Retrieves note from 3 weeks ago]
    "OAuth chosen over JWT because client requirement for third-party integrations"
@@ -225,7 +225,7 @@ Users can install memory-bank-mcp or Beads MCP servers and AIDP will automatical
 
 2. **User Preference Learning**
 
-   ```
+   ```text
    Agent stores: "User prefers RSpec over Minitest"
    Agent stores: "User coding style: early returns over nested conditionals"
    Future sessions automatically apply these preferences
@@ -233,7 +233,7 @@ Users can install memory-bank-mcp or Beads MCP servers and AIDP will automatical
 
 3. **Cross-Repository Patterns**
 
-   ```
+   ```text
    Agent working on Project B recalls:
    "In Project A, we solved similar pagination issue with cursor-based approach"
    ```
@@ -320,7 +320,7 @@ Users can install memory-bank-mcp or Beads MCP servers and AIDP will automatical
 
 1. **Multi-Session Task Management**
 
-   ```
+   ```text
    Session 1: Agent discovers "Need to add rate limiting" while implementing auth
    → Beads: Create issue, link as "discovered-from" current work
 
@@ -331,7 +331,7 @@ Users can install memory-bank-mcp or Beads MCP servers and AIDP will automatical
 
 2. **Long-Horizon Planning**
 
-   ```
+   ```text
    Agent builds dependency graph:
    - Setup database migrations [blocks]
    - Implement models [blocks]
@@ -344,7 +344,7 @@ Users can install memory-bank-mcp or Beads MCP servers and AIDP will automatical
 
 3. **Team Coordination**
 
-   ```
+   ```text
    Developer A's machine: Agent discovers security issue, files to Beads
    [git push]
    Developer B's machine: [git pull]
@@ -353,7 +353,7 @@ Users can install memory-bank-mcp or Beads MCP servers and AIDP will automatical
 
 4. **Compaction Continuity**
 
-   ```
+   ```text
    Traditional: Agent loses context after model compaction
    With Beads: Agent reads issue database, orients itself instantly
    "I was working on auth (issue #42), blocked on DB migration (issue #38)"
@@ -598,7 +598,7 @@ project_tracking:
 
 **File**: `templates/skills/memory_aware/SKILL.md`
 
-**Template showing how to leverage memory tools**
+#### Template showing how to leverage memory tools
 
 **Implementation**: 0.5 days
 
@@ -1140,7 +1140,7 @@ prompt_optimization:
 
 **Workflow**:
 
-```
+```text
 1. Agent reads Beads queue → "Work on #45: OAuth integration"
 
 2. Agent searches memory → Finds notes:

--- a/docs/PERSISTENT_TASKLIST.md
+++ b/docs/PERSISTENT_TASKLIST.md
@@ -575,7 +575,7 @@ end
 
 ### Integration Points
 
-**1. Work Loop Runner**
+#### 1. Work Loop Runner
 
 Inject persistent tasklist into work loop context:
 
@@ -607,7 +607,7 @@ def execute_step(step_name, step_spec, context = {})
 end
 ```
 
-**2. Agent Signal Parser**
+#### 2. Agent Signal Parser
 
 Parse task filing signals from agent responses:
 
@@ -1083,7 +1083,7 @@ Persistent tasklist provides 90% of external project tracking value at 10% of co
 
 **Friday afternoon - Discovery**:
 
-```
+```text
 Agent: "I'm implementing OAuth. I notice we'll need rate limiting for the token endpoint."
 Agent: File task: "Add rate limiting to /auth/token" priority: high
 System: 📋 Filed task: Add rate limiting to /auth/token (task_170310_a3f2)
@@ -1098,7 +1098,7 @@ System: 📋 Filed task: Update API docs with OAuth flow (task_170315_b8d1)
 
 **Monday morning - Resume**:
 
-```
+```text
 Developer: $ aidp execute
 
 System: 📋 You have 2 pending tasks from previous sessions:
@@ -1112,7 +1112,7 @@ Agent: "I see there are pending tasks. Let me work on rate limiting first."
 
 **Later - Check status**:
 
-```
+```text
 Developer: /tasks list pending
 
 PENDING (1)
@@ -1126,7 +1126,7 @@ IN PROGRESS (1)
 
 **Completion**:
 
-```
+```text
 Developer: /tasks done task_170310_a3f2
 System: ✓ Task marked as done: Add rate limiting to /auth/token
 

--- a/docs/SETUP_WIZARD.md
+++ b/docs/SETUP_WIZARD.md
@@ -31,6 +31,7 @@ aidp config --interactive --dry-run
 - Watch patterns for test reruns and default timeouts
 - Branching strategy (prefix, slug template, checkpoint tags)
 - Artifact directories for evidence packs, logs, and screenshots
+- Version control behavior (tool, commit behavior, commit message style, PR creation)
 
 ### Non-Functional Requirements (NFRs)
 

--- a/lib/aidp/watch/repository_client.rb
+++ b/lib/aidp/watch/repository_client.rb
@@ -162,7 +162,7 @@ module Aidp
         response.body
       end
 
-      def create_pull_request_via_gh(title:, body:, head:, base:, issue_number:)
+      def create_pull_request_via_gh(title:, body:, head:, base:, issue_number:, draft: false)
         cmd = [
           "gh", "pr", "create",
           "--repo", full_repo,
@@ -172,6 +172,7 @@ module Aidp
           "--base", base
         ]
         cmd += ["--issue", issue_number.to_s] if issue_number
+        cmd += ["--draft"] if draft
 
         stdout, stderr, status = Open3.capture3(*cmd)
         raise "Failed to create PR via gh: #{stderr.strip}" unless status.success?

--- a/spec/aidp/watch/build_processor_spec.rb
+++ b/spec/aidp/watch/build_processor_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe Aidp::Watch::BuildProcessor do
   end
 
   it "runs harness and posts success comment" do
+    # Create config with auto_create_pr enabled
+    config_path = File.join(tmp_dir, ".aidp", "aidp.yml")
+    FileUtils.mkdir_p(File.dirname(config_path))
+    config_hash = {
+      harness: {default_provider: "test_provider"},
+      providers: {test_provider: {type: "usage_based"}},
+      work_loop: {version_control: {auto_create_pr: true, pr_strategy: "draft"}}
+    }
+    File.write(config_path, YAML.dump(config_hash))
+    processor.instance_variable_set(:@config, nil) # Force config reload
+
     allow(processor).to receive(:run_harness).and_return({status: "completed", message: "done"})
     allow(processor).to receive(:create_pull_request).and_return("https://example.com/pr/77")
     expect(repository_client).to receive(:post_comment).with(issue[:number], include("Implementation complete"))

--- a/spec/aidp/watch/build_processor_vcs_spec.rb
+++ b/spec/aidp/watch/build_processor_vcs_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "aidp/watch/build_processor"
+require "aidp/harness/config_manager"
+
+RSpec.describe Aidp::Watch::BuildProcessor, "#vcs_preferences" do
+  let(:project_dir) { Dir.mktmpdir }
+  let(:repository_client) { double("RepositoryClient") }
+  let(:state_store) { double("StateStore") }
+  let(:processor) { described_class.new(repository_client: repository_client, state_store: state_store, project_dir: project_dir, use_workstreams: false) }
+  let(:issue) { {number: 123, title: "Add feature"} }
+
+  after { FileUtils.rm_rf(project_dir) }
+
+  def create_config(vcs_config)
+    config_path = File.join(project_dir, ".aidp", "aidp.yml")
+    FileUtils.mkdir_p(File.dirname(config_path))
+    # Include minimal required sections to pass validation
+    config_hash = {
+      harness: {
+        default_provider: "test_provider"
+      },
+      providers: {
+        test_provider: {
+          type: "usage_based"
+        }
+      },
+      work_loop: {
+        version_control: vcs_config
+      }
+    }
+    File.write(config_path, YAML.dump(config_hash))
+  end
+
+  describe "#build_commit_message" do
+    context "with conventional commits disabled" do
+      before do
+        create_config({conventional_commits: false, co_author_ai: false})
+        # Force config reload
+        processor.instance_variable_set(:@config, nil)
+      end
+
+      it "creates a simple commit message" do
+        message = processor.send(:build_commit_message, issue)
+        expect(message).to eq("implement #123 Add feature")
+      end
+    end
+
+    context "with conventional commits enabled (default style)" do
+      before do
+        create_config({conventional_commits: true, commit_style: "default", co_author_ai: false})
+        processor.instance_variable_set(:@config, nil)
+      end
+
+      it "creates a conventional commit message" do
+        message = processor.send(:build_commit_message, issue)
+        expect(message).to eq("feat: implement #123 Add feature")
+      end
+    end
+
+    context "with conventional commits enabled (angular style)" do
+      before do
+        create_config({conventional_commits: true, commit_style: "angular", co_author_ai: false})
+        processor.instance_variable_set(:@config, nil)
+      end
+
+      it "creates an angular-style commit message with scope" do
+        message = processor.send(:build_commit_message, issue)
+        expect(message).to eq("feat(implementation): implement #123 Add feature")
+      end
+    end
+
+    context "with conventional commits enabled (emoji style)" do
+      before do
+        create_config({conventional_commits: true, commit_style: "emoji", co_author_ai: false})
+        processor.instance_variable_set(:@config, nil)
+      end
+
+      it "creates an emoji-prefixed commit message" do
+        message = processor.send(:build_commit_message, issue)
+        expect(message).to start_with("✨ feat: implement #123 Add feature")
+      end
+    end
+
+    context "with co_author_ai enabled" do
+      before do
+        create_config({conventional_commits: false, co_author_ai: true})
+        processor.instance_variable_set(:@config, nil)
+        allow(processor).to receive(:detect_current_provider).and_return("Claude")
+      end
+
+      it "includes Co-authored-by line" do
+        message = processor.send(:build_commit_message, issue)
+        expect(message).to include("\n\nCo-authored-by: Claude <ai@aidp.dev>")
+      end
+    end
+
+    context "with co_author_ai disabled" do
+      before do
+        create_config({conventional_commits: false, co_author_ai: false})
+        processor.instance_variable_set(:@config, nil)
+      end
+
+      it "does not include Co-authored-by line" do
+        message = processor.send(:build_commit_message, issue)
+        expect(message).not_to include("Co-authored-by")
+      end
+    end
+
+    context "with all options enabled" do
+      before do
+        create_config({conventional_commits: true, commit_style: "emoji", co_author_ai: true})
+        processor.instance_variable_set(:@config, nil)
+        allow(processor).to receive(:detect_current_provider).and_return("Gemini")
+      end
+
+      it "creates a fully formatted commit message" do
+        message = processor.send(:build_commit_message, issue)
+        expect(message).to start_with("✨ feat: implement #123 Add feature")
+        expect(message).to include("\n\nCo-authored-by: Gemini <ai@aidp.dev>")
+      end
+    end
+  end
+
+  describe "#detect_current_provider" do
+    it "detects provider from config" do
+      config_path = File.join(project_dir, ".aidp", "aidp.yml")
+      FileUtils.mkdir_p(File.dirname(config_path))
+      File.write(config_path, YAML.dump({harness: {default_provider: "cursor"}}))
+
+      provider = processor.send(:detect_current_provider)
+      expect(provider).to eq("Cursor")
+    end
+
+    it "returns nil when config is missing" do
+      provider = processor.send(:detect_current_provider)
+      expect(provider).to be_nil
+    end
+  end
+
+  describe "PR creation behavior" do
+    let(:branch_name) { "aidp-issue-123" }
+    let(:base_branch) { "main" }
+    let(:plan_data) { {"summary" => "Implementation complete"} }
+    let(:slug) { "issue-123" }
+
+    before do
+      allow(processor).to receive(:stage_and_commit)
+      allow(processor).to receive(:plan_value).and_return("Implementation complete")
+      allow(state_store).to receive(:record_build_status)
+      allow(repository_client).to receive(:post_comment)
+    end
+
+    context "when auto_create_pr is disabled" do
+      before do
+        create_config({auto_create_pr: false})
+        processor.instance_variable_set(:@config, nil)
+      end
+
+      it "skips PR creation" do
+        expect(processor).not_to receive(:create_pull_request)
+
+        processor.send(:handle_success,
+          issue: issue,
+          slug: slug,
+          branch_name: branch_name,
+          base_branch: base_branch,
+          plan_data: plan_data,
+          working_dir: project_dir)
+      end
+
+      it "posts comment without PR URL" do
+        expect(repository_client).to receive(:post_comment) do |num, comment|
+          expect(num).to eq(123)
+          expect(comment).not_to include("Pull Request:")
+        end
+
+        processor.send(:handle_success,
+          issue: issue,
+          slug: slug,
+          branch_name: branch_name,
+          base_branch: base_branch,
+          plan_data: plan_data,
+          working_dir: project_dir)
+      end
+    end
+
+    context "when auto_create_pr is enabled with draft strategy" do
+      before do
+        create_config({auto_create_pr: true, pr_strategy: "draft"})
+        processor.instance_variable_set(:@config, nil)
+        allow(processor).to receive(:gather_test_summary).and_return("All tests passed")
+        allow(processor).to receive(:extract_pr_url).and_return("https://github.com/owner/repo/pull/456")
+      end
+
+      it "creates a draft PR" do
+        expect(repository_client).to receive(:create_pull_request) do |args|
+          expect(args[:draft]).to be true
+          "https://github.com/owner/repo/pull/456"
+        end
+
+        processor.send(:create_pull_request,
+          issue: issue,
+          branch_name: branch_name,
+          base_branch: base_branch,
+          working_dir: project_dir)
+      end
+    end
+
+    context "when auto_create_pr is enabled with ready strategy" do
+      before do
+        create_config({auto_create_pr: true, pr_strategy: "ready"})
+        processor.instance_variable_set(:@config, nil)
+        allow(processor).to receive(:gather_test_summary).and_return("All tests passed")
+        allow(processor).to receive(:extract_pr_url).and_return("https://github.com/owner/repo/pull/456")
+      end
+
+      it "creates a ready (non-draft) PR" do
+        expect(repository_client).to receive(:create_pull_request) do |args|
+          expect(args[:draft]).to be false
+          "https://github.com/owner/repo/pull/456"
+        end
+
+        processor.send(:create_pull_request,
+          issue: issue,
+          branch_name: branch_name,
+          base_branch: base_branch,
+          working_dir: project_dir)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add interactive setup options for conventional commits, commit style (default/angular/emoji), co-author AI attribution, and auto PR strategy
- Wire config into BuildProcessor: build commit messages per style, include Co-authored-by when enabled, respect auto_create_pr and pr_strategy (draft/ready/auto_merge)
- RepositoryClient: support creating draft PRs via gh CLI
- Add tests for commit message formatting and PR behavior; update existing specs to load config
- Update docs (CONFIGURATION, MEMORY_INTEGRATION, PERSISTENT_TASKLIST, SETUP_WIZARD) to document VCS options and examples
- Devcontainer/Dockerfile tweaks: multi-arch git-delta installer; remove pre-install of development gems and optional Claude CLI; update devcontainer postCreate/postStart commands

Fixes #182