### PR TITLE
fix: get devcontainer config building

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,12 @@
-# Development container for AIDP
-# Provides a sandboxed environment with all necessary tools and providers
-
+# Update the RUBY_VERSION arg in compose.yaml
 ARG RUBY_VERSION=3.4.5
-ARG TZ=UTC
+FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
-FROM ruby:${RUBY_VERSION}
+# Switch to root for system package installation
+USER root
 
 # Set timezone
-ARG TZ
+ARG TZ=UTC
 ENV TZ=${TZ}
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -23,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     # Networking tools
     iptables \
     ipset \
+    jq \
     dnsutils \
     netcat-openbsd \
     # Shell improvements
@@ -50,60 +50,24 @@ RUN ARCH="$(dpkg --print-architecture)" \
 RUN curl https://mise.run | sh
 ENV PATH="/root/.local/bin:$PATH"
 
-# Create non-root user
-ARG USERNAME=aidp
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+## Use base image non-root user (typically 'vscode'); ensure tooling & deps installed as root earlier.
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    && apt-get update \
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    && rm -rf /var/lib/apt/lists/*
-
-# Set up workspace directory
-RUN mkdir -p /workspace && chown -R $USERNAME:$USERNAME /workspace
-
-# Set up .aidp directory for configuration
-RUN mkdir -p /home/$USERNAME/.aidp && chown -R $USERNAME:$USERNAME /home/$USERNAME/.aidp
-
-# Set up command history persistence
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-    && mkdir -p /commandhistory \
-    && touch /commandhistory/.bash_history \
-    && chown -R $USERNAME:$USERNAME /commandhistory \
-    && echo "$SNIPPET" >> /home/$USERNAME/.bashrc
-
-# Install zsh with powerline10k theme
-ARG ZSH_IN_DOCKER_VERSION=1.2.0
-RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
-    -t https://github.com/romkatv/powerlevel10k \
-    -p git \
-    -p https://github.com/zsh-users/zsh-autosuggestions \
-    -p https://github.com/zsh-users/zsh-syntax-highlighting
-
-# Configure fzf key bindings and completion
-RUN echo '[ -f /usr/share/doc/fzf/examples/key-bindings.bash ] && source /usr/share/doc/fzf/examples/key-bindings.bash' >> /home/$USERNAME/.bashrc \
-    && echo '[ -f /usr/share/doc/fzf/examples/completion.bash ] && source /usr/share/doc/fzf/examples/completion.bash' >> /home/$USERNAME/.bashrc
-
-# Set nano as default editor
-ENV EDITOR=nano
+# (Optional tools installed later via devcontainer postCreateCommand based on user-selected flags.)
+RUN gem install bundler --no-document \
+  && npm install -g markdownlint-cli \
+  && npm cache clean --force || true
 
 # Copy firewall initialization script
-COPY init-firewall.sh /usr/local/bin/init-firewall.sh
+COPY .devcontainer/init-firewall.sh /usr/local/bin/init-firewall.sh
 RUN chmod +x /usr/local/bin/init-firewall.sh
 
-# Grant $USERNAME user sudo access to init-firewall.sh without password
-RUN echo "$USERNAME ALL=(ALL) NOPASSWD: /usr/local/bin/init-firewall.sh" >> /etc/sudoers.d/$USERNAME
+# Grant vscode user sudo access to init-firewall.sh without password (USER switched later)
+RUN echo "vscode ALL=(ALL) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/vscode-firewall && chmod 0440 /etc/sudoers.d/vscode-firewall
 
-# Switch to non-root user
-USER $USERNAME
-WORKDIR /workspace
+# Switch to base image user (vscode) for development
+USER vscode
+WORKDIR /workspaces/aidp
 
-# Install Ruby gems globally for development
-ENV GEM_HOME="/home/$USERNAME/.gem"
-ENV PATH="$GEM_HOME/bin:$PATH"
-
-CMD ["/bin/bash"]
+# Ensure binding is always 0.0.0.0
+# Binds the server to all IP addresses of the container, so it can be accessed from outside the container.
+ENV BINDING="0.0.0.0"

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,0 +1,29 @@
+name: "aidp-devcontainer"
+
+services:
+  aidp:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+      args:
+        # Update the RUBY_VERSION arg to match the Ruby version in .tool-versions
+        RUBY_VERSION: 3.4.5
+        DELTA_VERSION: 0.18.2
+
+    volumes:
+    - ../../aidp:/workspaces/aidp:cached
+
+    # Keep container running; init process handled via devcontainer tooling
+    command: sleep infinity
+    init: true
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+  #   depends_on:
+  #   - selenium
+
+  # selenium:
+  #   image: selenium/standalone-chromium
+  #   restart: unless-stopped
+
+  

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,35 +1,59 @@
+// For format details, see https://containers.dev/implementors/json_reference/.
+// For config options, see the README at: https://github.com/devcontainers/templates/tree/main/src/ruby
 {
   "name": "AIDP Development Container",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "args": {
-      "RUBY_VERSION": "3.4.5",
-      "TZ": "${localEnv:TZ:UTC}",
-      "DELTA_VERSION": "0.18.2",
-      "ZSH_IN_DOCKER_VERSION": "1.2.0"
-    }
-  },
+  "dockerComposeFile": "compose.yaml",
+  "service": "aidp",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+  // Use base image 'vscode' user for compatibility with devcontainer features
+  "remoteUser": "vscode",
 
   // Container configuration
   "capAdd": ["NET_ADMIN", "NET_RAW"],
-  "runArgs": ["--init"],
 
-  // Set environment variables
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    // GitHub CLI
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/rails/devcontainer/features/activestorage": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {"moby":false},
+    "ghcr.io/rails/devcontainer/features/sqlite3": {}
+  },
+
   "containerEnv": {
     "TZ": "${localEnv:TZ:UTC}",
     "AIDP_ENV": "development",
-    "BUNDLE_PATH": "/workspace/vendor/bundle"
+    "BUNDLE_PATH": "/workspaces/aidp/vendor/bundle"
   },
 
-  // Mount volumes for persistence
-  "mounts": [
-    // Persist bash history
-    "source=aidp-bashhistory,target=/commandhistory,type=volume",
-    // Persist .aidp configuration
-    "source=aidp-config,target=/home/aidp/.aidp,type=volume",
-    // Persist bundler cache
-    "source=aidp-bundle,target=/workspace/vendor/bundle,type=volume"
-  ],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [],
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // (Use root only for troubleshooting: set "remoteUser": "root" if needed.)
+
+
+  // Post-create command - install dependencies
+  // Post-create: mandatory bundle install; optional tools below (uncomment to enable)
+  "postCreateCommand": {
+    "bundle-install": "bundle check || bundle install --jobs 4 --retry 3"
+    // OPTIONAL TOOLS (uncomment any you want):
+    // "git-curate": "gem install git-curate --no-document || true",
+    // "claude-code": "npm install -g @anthropic-ai/claude-code || true",
+    // "gemini-cli": "npm install -g @google/gemini-cli || true",
+    // "github-copilot-cli": "npm install -g @githubnext/github-copilot-cli || true",
+    // "codex-cli": "npm install -g openai-cli || true"
+  },
+
+  // Post-start command - initialize firewall
+  "postStartCommand": {
+    "init-firewall": "sudo /usr/local/bin/init-firewall.sh",
+    "ensure-bundle": "bundle check || bundle install --jobs 4 --retry 3"
+  },
+  "waitFor": "postStartCommand",
 
   // VS Code customizations
   "customizations": {
@@ -85,39 +109,15 @@
     }
   },
 
-  // Container user
-  "remoteUser": "aidp",
-
-  // Working directory
-  "workspaceFolder": "/workspace",
-
-  // Post-create command - install dependencies
-  "postCreateCommand": {
-    "gem-dependencies": "gem install bundler git-curate || true",
-    "install-claude": "npm install -g @anthropic-ai/claude-code || true",
-    "install-markdownlint": "npm install -g markdownlint-cli || true"
-  },
-
-  // Post-start command - initialize firewall
-  "postStartCommand": {
-    "init-firewall": "sudo /usr/local/bin/init-firewall.sh",
-    "ensure-bundle": "bundle check || bundle install --jobs 4 --retry 3"
-  },
-  "waitFor": "postStartCommand",
-
-  // Features to install
-  "features": {
-    // GitHub CLI
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    // Docker-in-Docker (for testing)
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      // Debian trixie dropped moby packages; use Docker CE instead
-      "moby": false
-    }
-  },
-
-  // Port forwarding - none needed by default
-  "forwardPorts": [],
+  // Mount volumes for persistence
+  "mounts": [
+    // Persist bash history
+    "source=aidp-bashhistory,target=/commandhistory,type=volume",
+    // Persist .aidp configuration for vscode user
+    "source=aidp-config,target=/home/vscode/.aidp,type=volume",
+    // Persist bundler cache
+    "source=aidp-bundle,target=/workspace/vendor/bundle,type=volume"
+  ]
 
   // Optional: uncomment to keep container running
   // "overrideCommand": true

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ code_maat_analysis_report.md
 *.log
 tmp/aruba/*
 coverage/*
+
+# devcontainer caches
+vendor/bundle/*
+.vscode/


### PR DESCRIPTION
- Switches to using compose.yaml to define app + services (no services, currently)
- Swaps out the ruby container for the ruby devcontainer build
- Switches to use vscode user
- Adds better error handling in the init-firewall.sh script
- Modularizes postCreateCommands for more flexibility