### PR TITLE
feat: move PROMPT.md to .aidp/ and enable immediate archiving

### DIFF
--- a/lib/aidp/execute/work_loop_runner.rb
+++ b/lib/aidp/execute/work_loop_runner.rb
@@ -375,7 +375,7 @@ module Aidp
           previous_agent_summary: previous_summary
         )
 
-        @prompt_manager.write(initial_prompt)
+        @prompt_manager.write(initial_prompt, step_name: @step_name)
         display_message("  Created PROMPT.md (#{initial_prompt.length} chars)", type: :info)
       end
 
@@ -603,10 +603,10 @@ module Aidp
 
         return if test_results[:success] && lint_results[:success]
 
-        # Append failures to PROMPT.md
+        # Append failures to PROMPT.md and archive immediately (issue #224)
         current_prompt = @prompt_manager.read
         updated_prompt = current_prompt + "\n\n---\n\n" + failures.join("\n")
-        @prompt_manager.write(updated_prompt)
+        @prompt_manager.write(updated_prompt, step_name: @step_name)
 
         display_message("  [NEXT_PATCH] Added failure reports and diagnostic to PROMPT.md", type: :warning)
       end

--- a/spec/aidp/cli/issue_importer_bootstrap_spec.rb
+++ b/spec/aidp/cli/issue_importer_bootstrap_spec.rb
@@ -54,7 +54,10 @@ RSpec.describe Aidp::IssueImporter, "bootstrap" do
     allow(importer).to receive(:normalize_issue_identifier).and_return(issue_data[:url])
     allow(importer).to receive(:fetch_issue_data).and_return(issue_data)
     allow(importer).to receive(:display_imported_issue)
-    allow(importer).to receive(:create_work_loop_prompt) { File.write("PROMPT.md", "Initial") }
+    allow(importer).to receive(:create_work_loop_prompt) do
+      FileUtils.mkdir_p(".aidp")
+      File.write(".aidp/PROMPT.md", "Initial")
+    end
 
     importer.import_issue("org/repo#42")
 
@@ -62,7 +65,7 @@ RSpec.describe Aidp::IssueImporter, "bootstrap" do
     expect(Open3).to have_received(:capture3).with("git", "checkout", "-b", "aidp/iss-42-add-user-search")
     expect(Open3).to have_received(:capture3).with("git", "tag", "aidp-start/42")
 
-    content = File.read("PROMPT.md")
+    content = File.read(".aidp/PROMPT.md")
     expect(content).to match(/Detected Tooling/i)
   end
 
@@ -73,7 +76,10 @@ RSpec.describe Aidp::IssueImporter, "bootstrap" do
     allow(importer).to receive(:normalize_issue_identifier).and_return(issue_data[:url])
     allow(importer).to receive(:fetch_issue_data).and_return(issue_data)
     allow(importer).to receive(:display_imported_issue)
-    allow(importer).to receive(:create_work_loop_prompt) { File.write("PROMPT.md", "Initial") }
+    allow(importer).to receive(:create_work_loop_prompt) do
+      FileUtils.mkdir_p(".aidp")
+      File.write(".aidp/PROMPT.md", "Initial")
+    end
 
     # Mock git operations but they shouldn't be called
     allow(File).to receive(:exist?).with(".git").and_return(true)

--- a/spec/aidp/cli/issue_importer_spec.rb
+++ b/spec/aidp/cli/issue_importer_spec.rb
@@ -412,8 +412,9 @@ RSpec.describe Aidp::IssueImporter do
     it "creates PROMPT.md file" do
       importer.send(:create_work_loop_prompt, issue_data)
 
-      expect(File.exist?("PROMPT.md")).to be true
-      content = File.read("PROMPT.md")
+      prompt_path = File.join(".aidp", "PROMPT.md")
+      expect(File.exist?(prompt_path)).to be true
+      content = File.read(prompt_path)
 
       expect(content).to include("# Work Loop: GitHub Issue #123")
       expect(content).to include("Test Issue")


### PR DESCRIPTION
This commit implements GitHub issues #224 and #226:

Issue #224: Archive PROMPT.md immediately after creation
- Modified PromptManager.write() to accept optional step_name parameter
- Modified PromptManager.write_optimized() to archive after writing
- Archives are now created immediately when step_name is provided
- This ensures prompt_archive always contains all prompts sent to agents

Issue #226: Move PROMPT.md from project root to .aidp directory
- Updated PromptManager to create PROMPT.md at .aidp/PROMPT.md
- Updated IssueImporter to use PromptManager instead of direct file writes
- Updated WorkLoopRunner to pass step_name for immediate archiving
- Updated all test files to reflect new PROMPT.md location

Changes:
- lib/aidp/execute/prompt_manager.rb: Changed path to .aidp/PROMPT.md, added immediate archiving
- lib/aidp/cli/issue_importer.rb: Use PromptManager for all PROMPT.md operations
- lib/aidp/execute/work_loop_runner.rb: Pass step_name to write() calls
- spec/aidp/execute/prompt_manager_spec.rb: Updated path and added archiving tests
- spec/aidp/cli/issue_importer_spec.rb: Updated to use .aidp/PROMPT.md
- spec/aidp/cli/issue_importer_bootstrap_spec.rb: Updated mocks for new path

All tests passing.

Fixes #224 
Fixes #226 