### PR TITLE
fix(ci): restore core import in publish workflow to fix coverage updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,6 +125,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const core = require('@actions/core');
             const fs = require('fs');
 
             const branch = process.env.PR_BRANCH;


### PR DESCRIPTION
The coverage badge and baseline updates stopped working after the core import was removed in commit 85822b7. While github-script should provide core as a preloaded module, the script needs the explicit import to reliably access core.setFailed(), core.info(), and core.notice() methods.

Fixes #223