### PR TITLE
fix: Implement proper provider fallback chain for watch mode planning

### DIFF
--- a/lib/aidp/watch/plan_generator.rb
+++ b/lib/aidp/watch/plan_generator.rb
@@ -29,32 +29,103 @@ module Aidp
       def initialize(provider_name: nil, verbose: false)
         @provider_name = provider_name
         @verbose = verbose
+        @providers_attempted = []
       end
 
       def generate(issue)
-        provider = resolve_provider
-        if provider
-          generate_with_provider(provider, issue)
-        else
-          display_message("⚠️  No active provider available. Falling back to heuristic plan.", type: :warn)
-          heuristic_plan(issue)
+        Aidp.log_debug("plan_generator", "generate.start", provider: @provider_name, issue: issue[:number])
+
+        # Try providers in fallback chain order
+        providers_to_try = build_provider_fallback_chain
+        Aidp.log_debug("plan_generator", "fallback_chain", providers: providers_to_try, count: providers_to_try.size)
+
+        providers_to_try.each do |provider_name|
+          next if @providers_attempted.include?(provider_name)
+
+          Aidp.log_debug("plan_generator", "trying_provider", provider: provider_name, attempted: @providers_attempted)
+
+          provider = resolve_provider(provider_name)
+          unless provider
+            Aidp.log_debug("plan_generator", "provider_unavailable", provider: provider_name, reason: "not resolved")
+            @providers_attempted << provider_name
+            next
+          end
+
+          begin
+            Aidp.log_info("plan_generator", "generate_with_provider", provider: provider_name, issue: issue[:number])
+            result = generate_with_provider(provider, issue, provider_name)
+            if result
+              Aidp.log_info("plan_generator", "generation_success", provider: provider_name, issue: issue[:number])
+              return result
+            end
+
+            # Provider returned nil - try next provider
+            Aidp.log_warn("plan_generator", "provider_returned_nil", provider: provider_name)
+            @providers_attempted << provider_name
+          rescue => e
+            # Log error and try next provider in chain
+            Aidp.log_warn("plan_generator", "provider_failed", provider: provider_name, error: e.message, error_class: e.class.name)
+            @providers_attempted << provider_name
+          end
         end
+
+        # All providers exhausted, fall back to heuristic
+        Aidp.log_warn("plan_generator", "all_providers_exhausted", attempted: @providers_attempted, falling_back: "heuristic")
+        display_message("⚠️  All providers unavailable or failed. Falling back to heuristic plan.", type: :warn)
+        heuristic_plan(issue)
       rescue => e
-        display_message("⚠️  Plan generation failed (#{e.message}). Using heuristic.", type: :warn)
+        Aidp.log_error("plan_generator", "generation_failed_unexpectedly", error: e.message, backtrace: e.backtrace&.first(3))
+        display_message("⚠️  Plan generation failed unexpectedly (#{e.message}). Using heuristic.", type: :warn)
         heuristic_plan(issue)
       end
 
       private
 
-      def resolve_provider
-        provider_name = @provider_name || detect_default_provider
+      def build_provider_fallback_chain
+        # Start with specified provider or default
+        primary_provider = @provider_name || detect_default_provider
+        providers = []
+
+        # Add primary provider first
+        providers << primary_provider if primary_provider
+
+        # Try to get fallback chain from config
+        begin
+          config_manager = Aidp::Harness::ConfigManager.new(Dir.pwd)
+          fallback_providers = config_manager.fallback_providers || []
+
+          # Add fallback providers that aren't already in the list
+          fallback_providers.each do |fallback|
+            providers << fallback unless providers.include?(fallback)
+          end
+        rescue => e
+          Aidp.log_debug("plan_generator", "config_fallback_unavailable", error: e.message)
+        end
+
+        # If we still have no providers, add cursor as last resort
+        providers << "cursor" if providers.empty?
+
+        # Remove duplicates while preserving order
+        providers.uniq
+      end
+
+      def resolve_provider(provider_name = nil)
+        provider_name ||= @provider_name || detect_default_provider
         return nil unless provider_name
 
-        provider = Aidp::ProviderManager.get_provider(provider_name, use_harness: false)
-        return provider if provider&.available?
+        Aidp.log_debug("plan_generator", "resolve_provider", provider: provider_name)
 
+        provider = Aidp::ProviderManager.get_provider(provider_name, use_harness: false)
+
+        if provider&.available?
+          Aidp.log_debug("plan_generator", "provider_resolved", provider: provider_name, available: true)
+          return provider
+        end
+
+        Aidp.log_debug("plan_generator", "provider_not_available", provider: provider_name, available: provider&.available?)
         nil
       rescue => e
+        Aidp.log_warn("plan_generator", "resolve_provider_failed", provider: provider_name, error: e.message)
         display_message("⚠️  Failed to resolve provider #{provider_name}: #{e.message}", type: :warn)
         nil
       end
@@ -66,8 +137,10 @@ module Aidp
         "cursor"
       end
 
-      def generate_with_provider(provider, issue)
+      def generate_with_provider(provider, issue, provider_name = "unknown")
         payload = build_prompt(issue)
+
+        Aidp.log_debug("plan_generator", "sending_to_provider", provider: provider_name, prompt_length: payload.length)
 
         if @verbose
           display_message("\n--- Plan Generation Prompt ---", type: :muted)
@@ -77,6 +150,8 @@ module Aidp
 
         response = provider.send_message(prompt: payload)
 
+        Aidp.log_debug("plan_generator", "provider_response_received", provider: provider_name, response_length: response&.length || 0)
+
         if @verbose
           display_message("\n--- Provider Response ---", type: :muted)
           display_message(response.strip, type: :muted)
@@ -85,10 +160,14 @@ module Aidp
 
         parsed = parse_structured_response(response)
 
-        return parsed if parsed
+        if parsed
+          Aidp.log_debug("plan_generator", "response_parsed", provider: provider_name, has_summary: !parsed[:summary].to_s.empty?, tasks_count: parsed[:tasks]&.size || 0)
+          return parsed
+        end
 
-        display_message("⚠️  Unable to parse provider response. Using heuristic plan.", type: :warn)
-        heuristic_plan(issue)
+        Aidp.log_warn("plan_generator", "parse_failed", provider: provider_name)
+        display_message("⚠️  Unable to parse #{provider_name} response. Trying next provider.", type: :warn)
+        nil
       end
 
       def build_prompt(issue)


### PR DESCRIPTION
Fixes #304

This commit fixes the watch mode planning provider fallback mechanism which
was not working correctly when the primary provider was circuit broken or
timed out.

## Problem
When the primary provider was circuit broken and the first fallback provider
timed out, the system incorrectly fell back to a heuristic plan immediately
instead of trying additional fallback providers. This resulted in generic,
improperly formatted comments being posted to issues.

## Solution
- Refactored `PlanGenerator#generate` to iterate through the entire provider
  fallback chain before falling back to heuristic plan
- Added `build_provider_fallback_chain` method to construct the fallback
  chain from configuration
- Updated `resolve_provider` to accept a provider_name parameter
- Updated `generate_with_provider` to return nil on parse failure instead of
  immediately falling back to heuristic, allowing the fallback loop to
  continue
- Added comprehensive logging using Aidp.log_debug/info/warn/error throughout
  the provider selection and plan generation process

## Changes
- lib/aidp/watch/plan_generator.rb:
  - Add @providers_attempted instance variable to track providers tried
  - Implement provider fallback loop in generate method
  - Add build_provider_fallback_chain method
  - Update resolve_provider to accept provider_name parameter
  - Update generate_with_provider to return nil on failure
  - Add extensive logging throughout all methods

- spec/aidp/watch/plan_generator_spec.rb:
  - Update existing tests to mock build_provider_fallback_chain
  - Add new test context for multiple providers in fallback chain
  - Test provider fallback behavior when first provider fails
  - Test provider fallback when first provider is unavailable
  - Test heuristic fallback only when all providers exhausted

## Testing
All existing tests pass. New tests verify:
- Provider fallback works when first provider fails with timeout
- Provider fallback works when first provider is unavailable
- Heuristic plan is only used when all providers are exhausted