### PR TITLE
fix: Add missing IssueImporter require and namespace

### DIFF
--- a/lib/aidp/cli.rb
+++ b/lib/aidp/cli.rb
@@ -8,6 +8,7 @@ require_relative "harness/ui/enhanced_tui"
 require_relative "harness/ui/enhanced_workflow_selector"
 require_relative "harness/enhanced_runner"
 require_relative "cli/first_run_wizard"
+require_relative "cli/issue_importer"
 require_relative "rescue_logging"
 require_relative "concurrency"
 
@@ -669,7 +670,7 @@ module Aidp
             return
           end
 
-          importer = IssueImporter.new
+          importer = Aidp::IssueImporter.new
           issue_data = importer.import_issue(identifier)
 
           if issue_data


### PR DESCRIPTION
Fixes uninitialized constant error when running issue import commands.

- Add require_relative for cli/issue_importer.rb
- Use fully qualified Aidp::IssueImporter class name

This resolves the NameError that occurred when running:
  aidp issue import 123

All 7 specs in issue_import_workflow_spec.rb now pass.