### PR TITLE
fix: Resolve Zeitwerk constant loading errors in specs

### DIFF
--- a/lib/aidp/analyze/feature_analyzer.rb
+++ b/lib/aidp/analyze/feature_analyzer.rb
@@ -3,7 +3,8 @@
 require "fileutils"
 
 module Aidp
-  class FeatureAnalyzer
+  module Analyze
+    class FeatureAnalyzer
     def initialize(project_dir = Dir.pwd)
       @project_dir = project_dir
     end
@@ -392,6 +393,7 @@ module Aidp
     rescue
       # Fallback to filename if extraction fails
       File.basename(file, ".*").capitalize
+    end
     end
   end
 end

--- a/spec/aidp/analyze/feature_analyzer_spec.rb
+++ b/spec/aidp/analyze/feature_analyzer_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require "fileutils"
 require "aidp/analyze/feature_analyzer"
 
-RSpec.describe Aidp::FeatureAnalyzer do
+RSpec.describe Aidp::Analyze::FeatureAnalyzer do
   let(:project_dir) { Dir.mktmpdir }
   let(:analyzer) { described_class.new(project_dir) }
 

--- a/spec/aidp/harness/rspec_filter_strategy_spec.rb
+++ b/spec/aidp/harness/rspec_filter_strategy_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "spec_helper"
+
 RSpec.describe Aidp::Harness::RSpecFilterStrategy do
   let(:filter_instance) { instance_double(Aidp::Harness::OutputFilter, mode: :failures_only) }
   let(:strategy) { described_class.new }


### PR DESCRIPTION
Fixes three Zeitwerk autoloading issues:

1. FeatureAnalyzer: Wrap class in Aidp::Analyze module to match
   file path lib/aidp/analyze/feature_analyzer.rb
2. RSpecFilterStrategy spec: Add missing require "spec_helper"
3. Update FeatureAnalyzer spec to reference correct constant

All specs now pass without Zeitwerk::NameError exceptions.

Resolves spec failures in PR #383