### PR TITLE
fix: Rename PrWorktreeManager to PRWorktreeManager for Zeitwerk compliance

### DIFF
--- a/lib/aidp/pr_worktree_manager.rb
+++ b/lib/aidp/pr_worktree_manager.rb
@@ -4,7 +4,7 @@ require "shellwords"
 
 module Aidp
   # Manages worktrees specifically for Pull Request branches
-  class PrWorktreeManager
+  class PRWorktreeManager
     def initialize(base_repo_path: nil, project_dir: nil, worktree_registry_path: nil)
       @base_repo_path = base_repo_path || project_dir || Dir.pwd
       @project_dir = project_dir

--- a/spec/aidp/pr_worktree_manager_spec.rb
+++ b/spec/aidp/pr_worktree_manager_spec.rb
@@ -3,7 +3,7 @@ require "aidp/pr_worktree_manager"
 require "fileutils"
 require "tmpdir"
 
-RSpec.describe Aidp::PrWorktreeManager do
+RSpec.describe Aidp::PRWorktreeManager do
   let(:temp_repo_path) { Dir.mktmpdir }
   let(:pr_number) { 42 }
   let(:base_branch) { "main" }
@@ -22,7 +22,7 @@ RSpec.describe Aidp::PrWorktreeManager do
     end
 
     # Set the base repository path to the temporary repo with isolated project directory
-    @pr_worktree_manager = Aidp::PrWorktreeManager.new(
+    @pr_worktree_manager = Aidp::PRWorktreeManager.new(
       base_repo_path: temp_repo_path,
       project_dir: temp_repo_path
     )
@@ -252,7 +252,7 @@ RSpec.describe Aidp::PrWorktreeManager do
       let(:invalid_repo_path) { Dir.mktmpdir }
 
       it "raises an error" do
-        invalid_pr_worktree_manager = Aidp::PrWorktreeManager.new(
+        invalid_pr_worktree_manager = Aidp::PRWorktreeManager.new(
           base_repo_path: invalid_repo_path,
           project_dir: invalid_repo_path
         )
@@ -277,7 +277,7 @@ RSpec.describe Aidp::PrWorktreeManager do
       end
 
       it "handles non-writable registry gracefully" do
-        read_only_pr_worktree_manager = Aidp::PrWorktreeManager.new(
+        read_only_pr_worktree_manager = Aidp::PRWorktreeManager.new(
           base_repo_path: temp_repo_path,
           project_dir: read_only_dir
         )
@@ -311,7 +311,7 @@ RSpec.describe Aidp::PrWorktreeManager do
       it "handles corrupt registry gracefully" do
         allow(Aidp).to receive(:log_warn)
 
-        corrupt_pr_worktree_manager = Aidp::PrWorktreeManager.new(
+        corrupt_pr_worktree_manager = Aidp::PRWorktreeManager.new(
           base_repo_path: temp_repo_path,
           project_dir: temp_repo_path,
           worktree_registry_path: corrupt_registry_path


### PR DESCRIPTION
Zeitwerk expects constant names to match file naming conventions. The file
pr_worktree_manager.rb requires the class to be named PRWorktreeManager (with
PR in all caps) rather than PrWorktreeManager.

Changes:
- Rename class from PrWorktreeManager to PRWorktreeManager in lib/aidp/pr_worktree_manager.rb
- Update all references in spec/aidp/pr_worktree_manager_spec.rb

This fixes the Zeitwerk::NameError:
  expected file .../lib/aidp/pr_worktree_manager.rb to define constant
  Aidp::PRWorktreeManager, but didn't

Fixes #383