### PR TITLE
feat: Add deterministic STYLE_GUIDE section selector for prompt optimization

### DIFF
--- a/lib/aidp/style_guide/selector.rb
+++ b/lib/aidp/style_guide/selector.rb
@@ -1,0 +1,360 @@
+# frozen_string_literal: true
+
+module Aidp
+  module StyleGuide
+    # Deterministic selector for STYLE_GUIDE sections based on task context
+    #
+    # This class provides intelligent section selection from STYLE_GUIDE.md
+    # based on keywords in the task context. For providers with their own
+    # instruction files (Claude, GitHub Copilot), it skips style guide injection.
+    #
+    # @example Basic usage
+    #   selector = Selector.new(project_dir: "/path/to/project")
+    #   content = selector.select_sections(keywords: ["testing", "error"])
+    #
+    # @example Check if provider needs style guide
+    #   selector.provider_needs_style_guide?("cursor")    # => true
+    #   selector.provider_needs_style_guide?("claude")    # => false
+    class Selector
+      # Providers that have their own instruction files and don't need
+      # the style guide injected into prompts
+      PROVIDERS_WITH_INSTRUCTION_FILES = %w[
+        claude
+        anthropic
+        github_copilot
+      ].freeze
+
+      # Mapping of keywords/topics to STYLE_GUIDE.md line ranges
+      # Each entry is [start_line, end_line, description]
+      SECTION_MAPPING = {
+        # Core Engineering
+        "code_organization" => [[25, 117, "Code Organization"]],
+        "class" => [[25, 117, "Code Organization"], [217, 236, "Sandi Metz Rules"]],
+        "method" => [[224, 229, "Method Design"], [217, 236, "Sandi Metz Rules"]],
+        "composition" => [[29, 35, "Composition over Inheritance"]],
+        "inheritance" => [[29, 35, "Composition over Inheritance"]],
+        "small_objects" => [[25, 117, "Code Organization"]],
+        "single_responsibility" => [[25, 117, "Code Organization"]],
+
+        # Sandi Metz
+        "sandi_metz" => [[217, 236, "Sandi Metz Rules"]],
+        "parameter" => [[231, 236, "Parameter Limits"]],
+
+        # Ruby Conventions
+        "ruby" => [[259, 278, "Ruby Conventions"], [446, 498, "Ruby Version Management"]],
+        "naming" => [[51, 56, "Naming Conventions"]],
+        "convention" => [[259, 278, "Ruby Conventions"]],
+        "style" => [[259, 278, "Ruby Conventions"]],
+        "require" => [[263, 266, "Require Practices"]],
+        "mise" => [[446, 498, "Ruby Version Management"]],
+        "version" => [[446, 498, "Ruby Version Management"]],
+
+        # Feature Organization
+        "feature" => [[58, 116, "Feature Organization by Purpose"]],
+        "workflow" => [[58, 116, "Feature Organization by Purpose"]],
+        "template" => [[118, 210, "Template/Skill Separation"]],
+        "skill" => [[118, 210, "Template/Skill Separation"]],
+
+        # Logging
+        "logging" => [[287, 430, "Logging Practices"]],
+        "log" => [[287, 430, "Logging Practices"]],
+        "debug" => [[287, 430, "Logging Practices"]],
+
+        # ZFC - Zero Framework Cognition
+        "zfc" => [[500, 797, "Zero Framework Cognition (ZFC)"]],
+        "zero_framework" => [[500, 797, "Zero Framework Cognition (ZFC)"]],
+        "ai_decision" => [[500, 797, "Zero Framework Cognition (ZFC)"]],
+        "decision_engine" => [[500, 797, "Zero Framework Cognition (ZFC)"]],
+
+        # AGD - AI-Generated Determinism
+        "agd" => [[798, 855, "AI-Generated Determinism (AGD)"]],
+        "determinism" => [[798, 855, "AI-Generated Determinism (AGD)"]],
+        "config_time" => [[798, 855, "AI-Generated Determinism (AGD)"]],
+
+        # TTY / TUI
+        "tty" => [[856, 1105, "TTY Toolkit Guidelines"]],
+        "tui" => [[856, 1105, "TTY Toolkit Guidelines"]],
+        "ui" => [[856, 1105, "TTY Toolkit Guidelines"]],
+        "prompt" => [[856, 1105, "TTY Toolkit Guidelines"], [936, 972, "TTY Output Practices"]],
+        "progress" => [[856, 1105, "TTY Toolkit Guidelines"]],
+        "spinner" => [[856, 1105, "TTY Toolkit Guidelines"]],
+        "table" => [[856, 1105, "TTY Toolkit Guidelines"]],
+        "select" => [[856, 1105, "TTY Toolkit Guidelines"]],
+
+        # Testing
+        "testing" => [[1873, 2112, "Testing Guidelines"]],
+        "test" => [[1873, 2112, "Testing Guidelines"], [1550, 1800, "Test Coverage Philosophy"]],
+        "spec" => [[1873, 2112, "Testing Guidelines"]],
+        "rspec" => [[1873, 2112, "Testing Guidelines"]],
+        "mock" => [[1873, 2112, "Testing Guidelines"], [1930, 2012, "Dependency Injection"]],
+        "stub" => [[1873, 2112, "Testing Guidelines"]],
+        "coverage" => [[1550, 1800, "Test Coverage Philosophy"]],
+        "pending" => [[1816, 1870, "Pending Specs Policy"]],
+        "expect_script" => [[1173, 1234, "expect Scripts for TUI"]],
+        "tmux" => [[1203, 1295, "tmux Testing"]],
+        "time_test" => [[1656, 1690, "Time-based Testing"]],
+        "fork" => [[1718, 1778, "Forked Process Testing"]],
+        "encoding" => [[1780, 1813, "String Encoding"]],
+        "dependency_injection" => [[1930, 2012, "Dependency Injection"]],
+
+        # Error Handling
+        "error" => [[2113, 2168, "Error Handling"], [280, 286, "Error Handling Basics"]],
+        "exception" => [[2113, 2168, "Error Handling"], [2130, 2140, "Error Class Pattern"]],
+        "rescue" => [[280, 286, "Error Handling Basics"], [2113, 2168, "Error Handling"]],
+
+        # Concurrency
+        "concurrency" => [[2170, 2185, "Concurrency & Threads"]],
+        "thread" => [[2170, 2185, "Concurrency & Threads"]],
+        "async" => [[2170, 2185, "Concurrency & Threads"]],
+
+        # Performance
+        "performance" => [[2206, 2232, "Performance"]],
+        "optimization" => [[2206, 2232, "Performance"]],
+        "cache" => [[2206, 2232, "Performance"]],
+
+        # Security
+        "security" => [[2233, 2272, "Security & Safety"]],
+        "safety" => [[2233, 2272, "Security & Safety"]],
+        "validation" => [[2233, 2272, "Security & Safety"]],
+
+        # Backward Compatibility / Pre-release
+        "backward_compatibility" => [[2273, 2472, "Backward Compatibility"]],
+        "deprecation" => [[2273, 2472, "Backward Compatibility"]],
+        "legacy" => [[2273, 2472, "Backward Compatibility"]],
+
+        # Commit Hygiene
+        "commit" => [[2476, 2482, "Commit Hygiene"]],
+        "git" => [[2476, 2482, "Commit Hygiene"]],
+
+        # Prompt Optimization
+        "prompt_optimization" => [[2523, 2854, "Prompt Optimization"]],
+        "fragment" => [[2523, 2854, "Prompt Optimization"]],
+
+        # Task Filing
+        "task" => [[2856, 2890, "Task Filing"]],
+        "tasklist" => [[2856, 2890, "Task Filing"]]
+      }.freeze
+
+      # Default sections to always include (core rules)
+      CORE_SECTIONS = [
+        [25, 117, "Code Organization"],
+        [217, 236, "Sandi Metz Rules"],
+        [287, 430, "Logging Practices"]
+      ].freeze
+
+      attr_reader :project_dir
+
+      def initialize(project_dir:)
+        @project_dir = project_dir
+        @style_guide_content = nil
+        @style_guide_lines = nil
+      end
+
+      # Check if a provider needs style guide injection
+      #
+      # @param provider_name [String] Name of the provider
+      # @return [Boolean] true if style guide should be injected
+      def provider_needs_style_guide?(provider_name)
+        return true if provider_name.nil?
+
+        normalized = provider_name.to_s.downcase.strip
+        !PROVIDERS_WITH_INSTRUCTION_FILES.include?(normalized)
+      end
+
+      # Select relevant sections from STYLE_GUIDE.md based on keywords
+      #
+      # @param keywords [Array<String>] Keywords to match against
+      # @param include_core [Boolean] Whether to include core sections
+      # @param max_lines [Integer, nil] Maximum lines to return (nil for unlimited)
+      # @return [String] Combined content of selected sections
+      def select_sections(keywords: [], include_core: true, max_lines: nil)
+        Aidp.log_debug("style_guide_selector", "selecting_sections",
+          keywords: keywords, include_core: include_core, max_lines: max_lines)
+
+        return "" unless style_guide_exists?
+
+        # Gather all matching sections
+        sections = gather_sections(keywords, include_core)
+
+        # Merge overlapping ranges and sort
+        merged_ranges = merge_and_sort_ranges(sections)
+
+        # Extract content from ranges
+        content = extract_content(merged_ranges, max_lines)
+
+        Aidp.log_debug("style_guide_selector", "sections_selected",
+          section_count: merged_ranges.size, content_lines: content.lines.count)
+
+        content
+      end
+
+      # Extract keywords from task context
+      #
+      # @param context [Hash, String] Task context (description, affected files, etc.)
+      # @return [Array<String>] Extracted keywords
+      def extract_keywords(context)
+        text = context.is_a?(Hash) ? context.values.join(" ") : context.to_s
+        text_lower = text.downcase
+
+        keywords = []
+
+        SECTION_MAPPING.keys.each do |keyword|
+          # Convert keyword format (snake_case to spaces/variations)
+          patterns = build_patterns(keyword)
+          keywords << keyword if patterns.any? { |p| text_lower.include?(p) }
+        end
+
+        Aidp.log_debug("style_guide_selector", "keywords_extracted",
+          input_length: text.length, keywords_found: keywords.size)
+
+        keywords.uniq
+      end
+
+      # Get all available section names
+      #
+      # @return [Array<String>] List of all section mapping keys
+      def available_keywords
+        SECTION_MAPPING.keys.sort
+      end
+
+      # Check if style guide file exists
+      #
+      # @return [Boolean]
+      def style_guide_exists?
+        File.exist?(style_guide_path)
+      end
+
+      # Get information about what sections would be selected for given keywords
+      #
+      # @param keywords [Array<String>] Keywords to check
+      # @return [Array<Hash>] Section info with line ranges and descriptions
+      def preview_selection(keywords)
+        sections = gather_sections(keywords, false)
+        merged = merge_and_sort_ranges(sections)
+
+        merged.map do |start_line, end_line, description|
+          {
+            start_line: start_line,
+            end_line: end_line,
+            description: description,
+            estimated_lines: end_line - start_line + 1
+          }
+        end
+      end
+
+      private
+
+      def style_guide_path
+        File.join(@project_dir, "docs", "STYLE_GUIDE.md")
+      end
+
+      def style_guide_lines
+        @style_guide_lines ||= begin
+          return [] unless style_guide_exists?
+
+          content = File.read(style_guide_path, encoding: "UTF-8")
+          content = content.encode("UTF-8", invalid: :replace, undef: :replace)
+          content.lines
+        end
+      end
+
+      def gather_sections(keywords, include_core)
+        sections = []
+
+        # Add core sections if requested
+        sections.concat(CORE_SECTIONS.dup) if include_core
+
+        # Add sections matching keywords
+        keywords.each do |keyword|
+          normalized = keyword.to_s.downcase.gsub(/[^a-z0-9]/, "_")
+          if SECTION_MAPPING.key?(normalized)
+            sections.concat(SECTION_MAPPING[normalized])
+          end
+        end
+
+        sections
+      end
+
+      def merge_and_sort_ranges(sections)
+        return [] if sections.empty?
+
+        # Convert to sortable format and sort by start line
+        ranges = sections.map { |start_l, end_l, desc| [start_l.to_i, end_l.to_i, desc] }
+        ranges.sort_by!(&:first)
+
+        # Merge overlapping/adjacent ranges
+        merged = []
+        current_start, current_end, current_desc = ranges.first
+
+        ranges[1..].each do |start_l, end_l, desc|
+          if start_l <= current_end + 5 # Allow small gaps (5 lines)
+            # Extend current range
+            current_end = [current_end, end_l].max
+            current_desc = "#{current_desc}, #{desc}" unless current_desc.include?(desc)
+          else
+            # Save current range and start new one
+            merged << [current_start, current_end, current_desc]
+            current_start = start_l
+            current_end = end_l
+            current_desc = desc
+          end
+        end
+
+        # Don't forget the last range
+        merged << [current_start, current_end, current_desc]
+
+        merged
+      end
+
+      def extract_content(ranges, max_lines)
+        return "" if ranges.empty?
+
+        lines = style_guide_lines
+        return "" if lines.empty?
+
+        parts = []
+        total_lines = 0
+
+        ranges.each do |start_line, end_line, description|
+          break if max_lines && total_lines >= max_lines
+
+          # Adjust for 0-based indexing
+          start_idx = [start_line - 1, 0].max
+          end_idx = [end_line - 1, lines.length - 1].min
+
+          section_lines = lines[start_idx..end_idx]
+          next if section_lines.nil? || section_lines.empty?
+
+          # Add section header comment
+          parts << "<!-- Section: #{description} (lines #{start_line}-#{end_line}) -->"
+          parts << section_lines.join
+
+          total_lines += section_lines.length
+        end
+
+        content = parts.join("\n")
+
+        # Trim to max_lines if specified
+        if max_lines && content.lines.count > max_lines
+          content = content.lines.first(max_lines).join
+        end
+
+        content
+      end
+
+      def build_patterns(keyword)
+        patterns = [keyword]
+
+        # Add variations
+        patterns << keyword.tr("_", " ")
+        patterns << keyword.tr("_", "-")
+
+        # Add singular/plural variations for common terms
+        patterns << "#{keyword}s" unless keyword.end_with?("s")
+        patterns << keyword.chomp("s") if keyword.end_with?("s")
+
+        patterns.uniq
+      end
+    end
+  end
+end

--- a/spec/aidp/execute/work_loop_runner_spec.rb
+++ b/spec/aidp/execute/work_loop_runner_spec.rb
@@ -864,75 +864,120 @@ RSpec.describe Aidp::Execute::WorkLoopRunner do
     end
 
     describe "style guide reinforcement" do
+      # Provider-aware style guide selection: use a provider that needs style guide
+      # (providers like "cursor" need it; "anthropic"/"claude" have instruction files)
+      let(:cursor_provider_manager) do
+        instance_double("ProviderManager", current_provider: "cursor")
+      end
+      let(:cursor_runner) do
+        described_class.new(project_dir, cursor_provider_manager, config, prompt: test_prompt)
+      end
+
       describe "#should_reinject_style_guide?" do
-        it "returns false for iteration 1" do
-          runner.instance_variable_set(:@iteration_count, 1)
-          expect(runner.send(:should_reinject_style_guide?)).to be false
+        context "when provider needs style guide (cursor)" do
+          it "returns false for iteration 1" do
+            cursor_runner.instance_variable_set(:@iteration_count, 1)
+            expect(cursor_runner.send(:should_reinject_style_guide?)).to be false
+          end
+
+          it "returns false for iterations not at interval" do
+            cursor_runner.instance_variable_set(:@iteration_count, 3)
+            expect(cursor_runner.send(:should_reinject_style_guide?)).to be false
+          end
+
+          it "returns true for iteration 5" do
+            cursor_runner.instance_variable_set(:@iteration_count, 5)
+            expect(cursor_runner.send(:should_reinject_style_guide?)).to be true
+          end
+
+          it "returns true for iteration 10" do
+            cursor_runner.instance_variable_set(:@iteration_count, 10)
+            expect(cursor_runner.send(:should_reinject_style_guide?)).to be true
+          end
+
+          it "returns true for iteration 15" do
+            cursor_runner.instance_variable_set(:@iteration_count, 15)
+            expect(cursor_runner.send(:should_reinject_style_guide?)).to be true
+          end
         end
 
-        it "returns false for iterations not at interval" do
-          runner.instance_variable_set(:@iteration_count, 3)
-          expect(runner.send(:should_reinject_style_guide?)).to be false
-        end
-
-        it "returns true for iteration 5" do
-          runner.instance_variable_set(:@iteration_count, 5)
-          expect(runner.send(:should_reinject_style_guide?)).to be true
-        end
-
-        it "returns true for iteration 10" do
-          runner.instance_variable_set(:@iteration_count, 10)
-          expect(runner.send(:should_reinject_style_guide?)).to be true
-        end
-
-        it "returns true for iteration 15" do
-          runner.instance_variable_set(:@iteration_count, 15)
-          expect(runner.send(:should_reinject_style_guide?)).to be true
+        context "when provider has instruction file (anthropic)" do
+          it "returns false even at injection interval" do
+            runner.instance_variable_set(:@iteration_count, 5)
+            expect(runner.send(:should_reinject_style_guide?)).to be false
+          end
         end
       end
 
       describe "#reinject_style_guide_reminder" do
         before do
-          runner.instance_variable_set(:@iteration_count, 5)
-          runner.instance_variable_set(:@step_name, "test_step")
+          cursor_runner.instance_variable_set(:@iteration_count, 5)
+          cursor_runner.instance_variable_set(:@step_name, "test_step")
         end
 
         it "includes style guide content when available" do
-          allow(File).to receive(:exist?).with(/LLM_STYLE_GUIDE/).and_return(true)
-          allow(File).to receive(:read).with(/LLM_STYLE_GUIDE/).and_return("# Style Guide\nUse proper conventions")
+          # Mock the style_guide_selector to return content
+          mock_selector = instance_double(Aidp::StyleGuide::Selector)
+          allow(mock_selector).to receive(:provider_needs_style_guide?).and_return(true)
+          allow(mock_selector).to receive(:extract_keywords).and_return([])
+          allow(mock_selector).to receive(:select_sections).and_return("# Style Guide\nUse proper conventions")
+          cursor_runner.instance_variable_set(:@style_guide_selector, mock_selector)
 
-          reminder = runner.send(:reinject_style_guide_reminder)
+          reminder = cursor_runner.send(:reinject_style_guide_reminder)
 
           expect(reminder).to include("Style Guide & Template Reminder")
-          expect(reminder).to include("LLM Style Guide")
-          expect(reminder).to include("Use proper conventions")
+          expect(reminder).to include("Relevant Style Guide Sections")
           expect(reminder).to include("prevent drift")
         end
 
         it "truncates long style guides" do
-          long_style_guide = "x" * 2000
-          allow(File).to receive(:exist?).with(/LLM_STYLE_GUIDE/).and_return(true)
-          allow(File).to receive(:read).with(/LLM_STYLE_GUIDE/).and_return(long_style_guide)
+          long_style_guide = "x" * 3000
+          mock_selector = instance_double(Aidp::StyleGuide::Selector)
+          allow(mock_selector).to receive(:provider_needs_style_guide?).and_return(true)
+          allow(mock_selector).to receive(:extract_keywords).and_return([])
+          allow(mock_selector).to receive(:select_sections).and_return(long_style_guide)
+          cursor_runner.instance_variable_set(:@style_guide_selector, mock_selector)
 
-          reminder = runner.send(:reinject_style_guide_reminder)
+          reminder = cursor_runner.send(:reinject_style_guide_reminder)
 
           expect(reminder).to include("(truncated)")
           expect(reminder.length).to be < long_style_guide.length
         end
 
-        it "works when style guide is not available" do
-          allow(File).to receive(:exist?).and_return(false)
+        it "returns minimal reminder when style guide is not available" do
+          mock_selector = instance_double(Aidp::StyleGuide::Selector)
+          allow(mock_selector).to receive(:provider_needs_style_guide?).and_return(true)
+          allow(mock_selector).to receive(:extract_keywords).and_return([])
+          allow(mock_selector).to receive(:select_sections).and_return("")
+          cursor_runner.instance_variable_set(:@style_guide_selector, mock_selector)
 
-          reminder = runner.send(:reinject_style_guide_reminder)
+          reminder = cursor_runner.send(:reinject_style_guide_reminder)
 
           expect(reminder).to include("Style Guide & Template Reminder")
           expect(reminder).to include("prevent drift")
         end
 
         it "includes note about style violations" do
-          reminder = runner.send(:reinject_style_guide_reminder)
+          mock_selector = instance_double(Aidp::StyleGuide::Selector)
+          allow(mock_selector).to receive(:provider_needs_style_guide?).and_return(true)
+          allow(mock_selector).to receive(:extract_keywords).and_return([])
+          allow(mock_selector).to receive(:select_sections).and_return("# Style Guide")
+          cursor_runner.instance_variable_set(:@style_guide_selector, mock_selector)
+
+          reminder = cursor_runner.send(:reinject_style_guide_reminder)
 
           expect(reminder).to include("Test failures may indicate style guide violations")
+        end
+
+        context "when provider has instruction file" do
+          it "returns empty string for anthropic provider" do
+            runner.instance_variable_set(:@iteration_count, 5)
+            runner.instance_variable_set(:@step_name, "test_step")
+
+            reminder = runner.send(:reinject_style_guide_reminder)
+
+            expect(reminder).to eq("")
+          end
         end
       end
 
@@ -942,10 +987,16 @@ RSpec.describe Aidp::Execute::WorkLoopRunner do
         before do
           allow(Aidp::Execute::PromptManager).to receive(:new).and_return(prompt_manager)
           allow(prompt_manager).to receive(:read).and_return("# Current prompt content")
-          runner.instance_variable_set(:@iteration_count, 5)
+          cursor_runner.instance_variable_set(:@iteration_count, 5)
         end
 
-        it "includes style guide reminder at iteration 5" do
+        it "includes style guide reminder at iteration 5 for cursor provider" do
+          mock_selector = instance_double(Aidp::StyleGuide::Selector)
+          allow(mock_selector).to receive(:provider_needs_style_guide?).and_return(true)
+          allow(mock_selector).to receive(:extract_keywords).and_return([])
+          allow(mock_selector).to receive(:select_sections).and_return("# Style Guide")
+          cursor_runner.instance_variable_set(:@style_guide_selector, mock_selector)
+
           test_results = {
             success: false,
             output: "Test failures",
@@ -959,12 +1010,13 @@ RSpec.describe Aidp::Execute::WorkLoopRunner do
             expect(content).to include("Iteration 5")
           end
 
+          cursor_runner.instance_variable_set(:@prompt_manager, prompt_manager)
           all_results = empty_all_results.merge(tests: test_results, lints: lint_results)
-          runner.send(:prepare_next_iteration, all_results, diagnostic)
+          cursor_runner.send(:prepare_next_iteration, all_results, diagnostic)
         end
 
         it "does not include style guide reminder at iteration 3" do
-          runner.instance_variable_set(:@iteration_count, 3)
+          cursor_runner.instance_variable_set(:@iteration_count, 3)
 
           test_results = {
             success: false,
@@ -978,8 +1030,9 @@ RSpec.describe Aidp::Execute::WorkLoopRunner do
             expect(content).not_to include("Style Guide & Template Reminder")
           end
 
+          cursor_runner.instance_variable_set(:@prompt_manager, prompt_manager)
           all_results = empty_all_results.merge(tests: test_results, lints: lint_results)
-          runner.send(:prepare_next_iteration, all_results, diagnostic)
+          cursor_runner.send(:prepare_next_iteration, all_results, diagnostic)
         end
       end
     end

--- a/spec/aidp/style_guide/selector_spec.rb
+++ b/spec/aidp/style_guide/selector_spec.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require_relative "../../../lib/aidp/style_guide/selector"
+
+RSpec.describe Aidp::StyleGuide::Selector do
+  let(:temp_dir) { Dir.mktmpdir }
+  let(:selector) { described_class.new(project_dir: temp_dir) }
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  describe "#initialize" do
+    it "initializes with project directory" do
+      expect(selector.project_dir).to eq(temp_dir)
+    end
+  end
+
+  describe "#provider_needs_style_guide?" do
+    context "when provider has instruction file" do
+      it "returns false for claude" do
+        expect(selector.provider_needs_style_guide?("claude")).to be false
+      end
+
+      it "returns false for anthropic" do
+        expect(selector.provider_needs_style_guide?("anthropic")).to be false
+      end
+
+      it "returns false for github_copilot" do
+        expect(selector.provider_needs_style_guide?("github_copilot")).to be false
+      end
+
+      it "handles case insensitivity" do
+        expect(selector.provider_needs_style_guide?("CLAUDE")).to be false
+        expect(selector.provider_needs_style_guide?("Claude")).to be false
+      end
+
+      it "handles whitespace" do
+        expect(selector.provider_needs_style_guide?("  claude  ")).to be false
+      end
+    end
+
+    context "when provider needs style guide" do
+      it "returns true for cursor" do
+        expect(selector.provider_needs_style_guide?("cursor")).to be true
+      end
+
+      it "returns true for gemini" do
+        expect(selector.provider_needs_style_guide?("gemini")).to be true
+      end
+
+      it "returns true for opencode" do
+        expect(selector.provider_needs_style_guide?("opencode")).to be true
+      end
+
+      it "returns true for kilocode" do
+        expect(selector.provider_needs_style_guide?("kilocode")).to be true
+      end
+
+      it "returns true for codex" do
+        expect(selector.provider_needs_style_guide?("codex")).to be true
+      end
+
+      it "returns true for aider" do
+        expect(selector.provider_needs_style_guide?("aider")).to be true
+      end
+
+      it "returns true for nil provider" do
+        expect(selector.provider_needs_style_guide?(nil)).to be true
+      end
+    end
+  end
+
+  describe "#style_guide_exists?" do
+    context "when style guide does not exist" do
+      it "returns false" do
+        expect(selector.style_guide_exists?).to be false
+      end
+    end
+
+    context "when style guide exists" do
+      before do
+        docs_dir = File.join(temp_dir, "docs")
+        FileUtils.mkdir_p(docs_dir)
+        File.write(File.join(docs_dir, "STYLE_GUIDE.md"), sample_style_guide)
+      end
+
+      it "returns true" do
+        expect(selector.style_guide_exists?).to be true
+      end
+    end
+  end
+
+  describe "#select_sections" do
+    context "when style guide does not exist" do
+      it "returns empty string" do
+        content = selector.select_sections(keywords: ["testing"])
+        expect(content).to eq("")
+      end
+    end
+
+    context "when style guide exists" do
+      before do
+        docs_dir = File.join(temp_dir, "docs")
+        FileUtils.mkdir_p(docs_dir)
+        File.write(File.join(docs_dir, "STYLE_GUIDE.md"), sample_style_guide)
+      end
+
+      it "returns content for matching keywords" do
+        content = selector.select_sections(keywords: ["testing"])
+        expect(content).not_to be_empty
+      end
+
+      it "includes core sections by default" do
+        content = selector.select_sections(keywords: [])
+        expect(content).not_to be_empty
+      end
+
+      it "can exclude core sections" do
+        content_with_core = selector.select_sections(keywords: [], include_core: true)
+        content_without_core = selector.select_sections(keywords: [], include_core: false)
+
+        expect(content_with_core.length).to be > content_without_core.length
+      end
+
+      it "respects max_lines limit" do
+        content = selector.select_sections(keywords: [], include_core: true, max_lines: 10)
+        expect(content.lines.count).to be <= 10
+      end
+
+      it "adds section comments to output" do
+        content = selector.select_sections(keywords: ["testing"])
+        expect(content).to include("<!-- Section:")
+      end
+    end
+  end
+
+  describe "#extract_keywords" do
+    it "extracts keywords from string" do
+      keywords = selector.extract_keywords("We need to add testing for error handling")
+      expect(keywords).to include("testing")
+      expect(keywords).to include("error")
+    end
+
+    it "extracts keywords from hash" do
+      keywords = selector.extract_keywords({
+        description: "Add error handling",
+        notes: "Security considerations"
+      })
+      expect(keywords).to include("error")
+      expect(keywords).to include("security")
+    end
+
+    it "returns unique keywords" do
+      keywords = selector.extract_keywords("testing test tests")
+      expect(keywords.count("testing")).to be <= 1
+    end
+
+    it "returns empty array for empty input" do
+      keywords = selector.extract_keywords("")
+      expect(keywords).to eq([])
+    end
+
+    it "handles nil input" do
+      keywords = selector.extract_keywords(nil)
+      expect(keywords).to eq([])
+    end
+  end
+
+  describe "#available_keywords" do
+    it "returns all section mapping keys" do
+      keywords = selector.available_keywords
+      expect(keywords).to be_an(Array)
+      expect(keywords).not_to be_empty
+    end
+
+    it "returns sorted keywords" do
+      keywords = selector.available_keywords
+      expect(keywords).to eq(keywords.sort)
+    end
+
+    it "includes common keywords" do
+      keywords = selector.available_keywords
+      expect(keywords).to include("testing")
+      expect(keywords).to include("error")
+      expect(keywords).to include("zfc")
+      expect(keywords).to include("tty")
+    end
+  end
+
+  describe "#preview_selection" do
+    before do
+      docs_dir = File.join(temp_dir, "docs")
+      FileUtils.mkdir_p(docs_dir)
+      File.write(File.join(docs_dir, "STYLE_GUIDE.md"), sample_style_guide)
+    end
+
+    it "returns section info for keywords" do
+      preview = selector.preview_selection(["testing"])
+      expect(preview).to be_an(Array)
+    end
+
+    it "includes line range information" do
+      preview = selector.preview_selection(["testing"])
+      next if preview.empty?
+
+      first_section = preview.first
+      expect(first_section).to have_key(:start_line)
+      expect(first_section).to have_key(:end_line)
+      expect(first_section).to have_key(:description)
+      expect(first_section).to have_key(:estimated_lines)
+    end
+
+    it "returns empty array for non-matching keywords" do
+      preview = selector.preview_selection(["nonexistent_keyword_xyz"])
+      expect(preview).to eq([])
+    end
+  end
+
+  describe "SECTION_MAPPING" do
+    it "contains expected keywords" do
+      expect(described_class::SECTION_MAPPING).to have_key("testing")
+      expect(described_class::SECTION_MAPPING).to have_key("error")
+      expect(described_class::SECTION_MAPPING).to have_key("zfc")
+      expect(described_class::SECTION_MAPPING).to have_key("tty")
+      expect(described_class::SECTION_MAPPING).to have_key("logging")
+    end
+
+    it "has valid line ranges for all entries" do
+      described_class::SECTION_MAPPING.each do |keyword, sections|
+        sections.each do |start_line, end_line, description|
+          expect(start_line).to be_a(Integer), "Invalid start_line for #{keyword}"
+          expect(end_line).to be_a(Integer), "Invalid end_line for #{keyword}"
+          expect(start_line).to be > 0, "start_line must be positive for #{keyword}"
+          expect(end_line).to be >= start_line, "end_line must be >= start_line for #{keyword}"
+          expect(description).to be_a(String), "description must be a string for #{keyword}"
+        end
+      end
+    end
+  end
+
+  describe "PROVIDERS_WITH_INSTRUCTION_FILES" do
+    it "includes claude" do
+      expect(described_class::PROVIDERS_WITH_INSTRUCTION_FILES).to include("claude")
+    end
+
+    it "includes anthropic" do
+      expect(described_class::PROVIDERS_WITH_INSTRUCTION_FILES).to include("anthropic")
+    end
+
+    it "includes github_copilot" do
+      expect(described_class::PROVIDERS_WITH_INSTRUCTION_FILES).to include("github_copilot")
+    end
+  end
+
+  describe "CORE_SECTIONS" do
+    it "is not empty" do
+      expect(described_class::CORE_SECTIONS).not_to be_empty
+    end
+
+    it "has valid structure" do
+      described_class::CORE_SECTIONS.each do |start_line, end_line, description|
+        expect(start_line).to be_a(Integer)
+        expect(end_line).to be_a(Integer)
+        expect(description).to be_a(String)
+      end
+    end
+  end
+
+  def sample_style_guide
+    # Create a sample with line numbers that match some expected ranges
+    lines = Array.new(3000) { |i| "Line #{i + 1}: Sample content\n" }
+
+    # Add some section markers at expected positions
+    lines[24] = "## Code Organization\n"
+    lines[50] = "### Naming Conventions\n"
+    lines[216] = "## Sandi Metz Rules\n"
+    lines[286] = "### Logging Practices\n"
+    lines[499] = "## Zero Framework Cognition (ZFC)\n"
+    lines[855] = "## TTY Toolkit Guidelines\n"
+    lines[1872] = "## Testing Guidelines\n"
+    lines[2112] = "## Error Handling\n"
+
+    lines.join
+  end
+end


### PR DESCRIPTION
- Create Aidp::StyleGuide::Selector class for intelligent section selection
- Skip style guide injection for Claude and GitHub Copilot providers
  (they have their own instruction files: CLAUDE.md, copilot_instructions.md)
- For other providers, select relevant STYLE_GUIDE.md sections based on
  task context keywords instead of injecting entire LLM_STYLE_GUIDE
- Implement keyword-to-section mapping based on LLM_STYLE_GUIDE references
- Update work_loop_runner to use provider-aware style guide loading
- Add comprehensive unit tests for the new Selector class
- Update existing tests to accommodate provider-aware behavior

Closes #380