### PR TITLE
feat: Add --launch-test option for CI/CD validation

### DIFF
--- a/spec/integration/cli_basic_commands_spec.rb
+++ b/spec/integration/cli_basic_commands_spec.rb
@@ -370,6 +370,38 @@ RSpec.describe "CLI Basic Commands Integration", type: :integration do
 
       expect(Aidp::Watch::Runner).to have_received(:new).with(hash_including(provider_name: "claude"))
     end
+
+    describe "--launch-test flag" do
+      before do
+        allow(Aidp).to receive(:log_debug)
+        allow(Aidp).to receive(:log_info)
+      end
+
+      it "returns 0 when launch test succeeds" do
+        result = Aidp::CLI.send(:run_watch_command, ["https://github.com/owner/repo/issues", "--launch-test"])
+
+        expect(result).to eq(0)
+      end
+
+      it "does not start watch runner during launch test" do
+        Aidp::CLI.send(:run_watch_command, ["https://github.com/owner/repo/issues", "--launch-test"])
+
+        expect(Aidp::Watch::Runner).not_to have_received(:new)
+        expect(watch_runner).not_to have_received(:start)
+      end
+
+      it "loads and validates configuration during launch test" do
+        Aidp::CLI.send(:run_watch_command, ["https://github.com/owner/repo/issues", "--launch-test"])
+
+        expect(Aidp::Harness::ConfigManager).to have_received(:new)
+      end
+
+      it "displays success message after launch test" do
+        Aidp::CLI.send(:run_watch_command, ["https://github.com/owner/repo/issues", "--launch-test"])
+
+        expect(Aidp::CLI).to have_received(:display_message).with(/Launch test completed successfully/, type: :success)
+      end
+    end
   end
 
   describe "work command" do


### PR DESCRIPTION
Implements issue #403 - adds an undocumented --launch-test option that
validates end-to-end initialization of the app without running full
workflows. This enables e2e system testing in CI/CD pipelines.

Features:
- Add --launch-test option for interactive mode
- Add --launch-test option for watch mode
- Initialize and verify critical components (TUI, WorkflowSelector, ConfigManager)
- Print version and exit cleanly after validation
- Proper error handling and logging

Tests:
- Unit tests for parse_options recognizing --launch-test
- Unit tests for interactive mode launch test
- Integration tests for watch mode launch test