### PR TITLE
fix: Include missing requirements and additional work in incomplete implementation warning

### DIFF
--- a/lib/aidp/watch/review_processor.rb
+++ b/lib/aidp/watch/review_processor.rb
@@ -204,12 +204,35 @@ module Aidp
           else
             parts << "### ⚠️ Implementation Incomplete"
             parts << ""
-            parts << "**This PR appears to be incomplete based on the linked issue requirements:**"
+            parts << "**This PR appears to be incomplete based on the linked issue requirements.**"
             parts << ""
-            verification_result[:reasons]&.each do |reason|
-              parts << "- #{reason}"
+
+            # Show the verification reasoning
+            if verification_result[:reason]
+              parts << "**Summary:** #{verification_result[:reason]}"
+              parts << ""
             end
-            parts << ""
+
+            # Show missing requirements for implementers to address
+            if verification_result[:missing_items]&.any?
+              parts << "**Missing Requirements:**"
+              parts << ""
+              verification_result[:missing_items].each do |item|
+                parts << "- #{item}"
+              end
+              parts << ""
+            end
+
+            # Show additional work needed for implementers
+            if verification_result[:additional_work]&.any?
+              parts << "**Additional Work Needed:**"
+              parts << ""
+              verification_result[:additional_work].each do |work|
+                parts << "- #{work}"
+              end
+              parts << ""
+            end
+
             parts << "**Suggested Action:** Add the `aidp-request-changes` label if you'd like AIDP to help complete the implementation."
           end
           parts << ""


### PR DESCRIPTION
When a PR is marked as incomplete, the review comment now includes
detailed guidance with:
- Summary: The verification reasoning
- Missing Requirements: Specific requirements not yet addressed
- Additional Work Needed: Tasks needed to complete the implementation

This gives implementers actionable information when the aidp-request-changes
label is added, helping them complete the implementation.

Also fixes a key mismatch bug where the code used :reasons (plural) but
the verifier returned :reason (singular).

Fixes #364