### PR TITLE
fix: Exclude capability_registry from provider selection menu

### DIFF
--- a/lib/aidp/setup/wizard.rb
+++ b/lib/aidp/setup/wizard.rb
@@ -105,8 +105,8 @@ module Aidp
         providers_dir = File.join(__dir__, "../providers")
         provider_files = Dir.glob("*.rb", base: providers_dir)
 
-        # Exclude base classes
-        excluded_files = ["base.rb"]
+        # Exclude base classes and non-provider utility files
+        excluded_files = ["base.rb", "adapter.rb", "capability_registry.rb", "error_taxonomy.rb"]
         provider_files -= excluded_files
 
         providers = {}


### PR DESCRIPTION
The discover_available_providers method was scanning all .rb files in
lib/aidp/providers/ but only excluding base.rb. This caused
capability_registry.rb (and potentially adapter.rb, error_taxonomy.rb)
to appear in the provider selection menu during configuration.

Added these non-provider utility files to the excluded_files list to
prevent them from appearing in user-facing provider selection menus.

Fixes #297