### PR TITLE
fix(watch): add GIT_EDITOR fix to apply_conflict_resolution method

### DIFF
--- a/lib/aidp/watch/rebase_processor.rb
+++ b/lib/aidp/watch/rebase_processor.rb
@@ -188,7 +188,9 @@ module Aidp
         end
 
         # Stage and continue rebase
-        @shell_executor.system("cd #{worktree_path} && git add . && git rebase --continue")
+        # GIT_EDITOR=true prevents editor from opening during automated rebase
+        @shell_executor.system("cd #{worktree_path} && git add .")
+        @shell_executor.system({"GIT_EDITOR" => "true"}, "cd #{worktree_path} && git rebase --continue")
       end
 
       def post_rebase_status(pr_number, rebase_result, error_detail = nil)


### PR DESCRIPTION
## Summary
- Adds `GIT_EDITOR=true` to the `apply_conflict_resolution` method to prevent editor from opening during automated rebase operations
- This completes the GIT_EDITOR fix that was partially applied in the `perform_rebase` method (line 141) but was missing from `apply_conflict_resolution` (line 191)

## Context
The `aidp-rebase` feature was already implemented and merged in commit afa4c95. This PR only adds the missing `GIT_EDITOR=true` environment variable to one location that was missed.

## Test plan
- [x] Existing rebase_processor_spec.rb tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)